### PR TITLE
Fix for crash which would occur when trying to save more than 4000 characters into a SQLServerCE NText column

### DIFF
--- a/PetaPoco/PetaPoco.cs
+++ b/PetaPoco/PetaPoco.cs
@@ -422,6 +422,9 @@ namespace PetaPoco
 				}
 				else if (t == typeof(string))
 				{
+					if ((item as string).Length + 1 > 4000 && p.GetType().Name == "SqlCeParameter")
+						p.GetType().GetProperty("SqlDbType").SetValue(p, SqlDbType.NText, null); // out of memory exception occurs if trying to save more than 4000 characters to SQL Server CE NText column. Set before attempting to set Size, or Size will always max out at 4000
+
 					p.Size = Math.Max((item as string).Length + 1, 4000);		// Help query plan caching by using common size
 					p.Value = item;
 				}


### PR DESCRIPTION
Fix for crash which would occur when trying to save more than 4000 characters into a SQLServerCE NText column
