### PR TITLE
Allow Nullable T in ExecuteScalar

### DIFF
--- a/PetaPoco/PetaPoco.cs
+++ b/PetaPoco/PetaPoco.cs
@@ -551,7 +551,17 @@ namespace PetaPoco
 					{
 						object val = cmd.ExecuteScalar();
 						OnExecutedCommand(cmd);
-						return (T)Convert.ChangeType(val, typeof(T));
+						
+						Type t = typeof(T);
+						Type u = Nullable.GetUnderlyingType(t);
+
+						if (u != null) {
+							if (val == null) return default(T);
+							return (T)Convert.ChangeType(val, u);
+						}
+						else {
+							return (T)Convert.ChangeType(val, t);
+						}						
 					}
 				}
 				finally


### PR DESCRIPTION
The ExecuteScalar method uses

```
return (T)Convert.ChangeType(val, typeof(T));
```

This does not work when T is Nullable. Using a sample from LukeH (http://stackoverflow.com/questions/793714/how-can-i-fix-this-up-to-do-generic-conversion-to-nullablet/793893#793893) I changed that single line to read

```
Type t = typeof(T);
Type u = Nullable.GetUnderlyingType(t);

if (u != null) {
    if (val == null) return default(T);
    return (T)Convert.ChangeType(val, u);
}
else {
    return (T)Convert.ChangeType(val, t);
}
```

This allows the function to return a null. The same issue exists for the Single method.
