### PR TITLE
Fix: ensure the primary key value is returned from Insert() when the primary key column is not an autoincrement. 

### DIFF
--- a/PetaPoco/PetaPoco.cs
+++ b/PetaPoco/PetaPoco.cs
@@ -1226,7 +1226,12 @@ namespace PetaPoco
 							DoPreExecute(cmd);
 							cmd.ExecuteNonQuery();
 							OnExecutedCommand(cmd);
-							return true;
+                            
+                            PocoColumn pkColumn;
+                            if (primaryKeyName != null && pd.Columns.TryGetValue(primaryKeyName, out pkColumn))
+                                return pkColumn.GetValue(poco);
+                            else
+                                return null;
 						}
 
 


### PR DESCRIPTION
Previously, Insert()  was always returning "true" when inserting into a table where the PK was not an autoincrementing id. Changed to ensure the PK value is returned in this scenario instead, which is what the comments indicate as being the case at the top of the method.
