### PR TITLE
Add IsNew() Support for PK of Type Guid

### DIFF
--- a/PetaPoco/PetaPoco.cs
+++ b/PetaPoco/PetaPoco.cs
@@ -1561,6 +1561,8 @@ namespace PetaPoco
 					return (int)pk == 0;
 				else if (type == typeof(uint))
 					return (uint)pk == 0;
+				else if (type == typeof(Guid))
+					return (Guid)pk == Guid.Empty;
 
 				// Create a default instance and compare
 				return pk == Activator.CreateInstance(pk.GetType());


### PR DESCRIPTION
We had decorated our Entities with an IsNew() property, but then I saw that PetaPoco had a similar helper method on the Database class. However, the PetaPoco db.IsNew("Id", entity) did not detect an Guid.Empty as being new.

``` c#
public bool IsNew()
{
    return Id == Guid.Empty;
}
```
