### PR TITLE
Check connection state prior to Open() to avoid error: System.InvalidOperation

### DIFF
--- a/PetaPoco/PetaPoco.cs
+++ b/PetaPoco/PetaPoco.cs
@@ -232,7 +232,12 @@ namespace PetaPoco
 			{
 				_sharedConnection = _factory.CreateConnection();
 				_sharedConnection.ConnectionString = _connectionString;
-				_sharedConnection.Open();
+
+				if(_sharedConnection.State == ConnectionState.Broken)
+					_sharedConnection.Close();
+
+				if(_sharedConnection.State == ConnectionState.Closed)
+					_sharedConnection.Open();
 
 				_sharedConnection = OnConnectionOpened(_sharedConnection);
 


### PR DESCRIPTION
Encountered a scenario where the connection state was <code>ConnectionState.Connecting</code> when PetaPoco tried to issue <code>_sharedConnection.Open();</code> to execute a query.

```
System.InvalidOperationException: The connection was not closed. The connection's current state is connecting.
   at System.Data.ProviderBase.DbConnectionBusy.OpenConnection(DbConnection outerConnection, DbConnectionFactory connectionFactory)
   at System.Data.SqlClient.SqlConnection.Open()
   at Samp.Core.Database.OpenSharedConnection() in C:\@Sample\projects\samp\src\Core\PetaPoco.cs:line 234
   at Samp.Core.Database.<Query>d__7`1.MoveNext() in C:\@Sample\projects\samp\src\Core\PetaPoco.cs:line 747
   at System.Linq.Enumerable.SingleOrDefault[TSource](IEnumerable`1 source)
   at Samp.Core.Database.SingleOrDefault[T](Sql sql) in C:\@Sample\projects\samp\src\Core\PetaPoco.cs:line 1140
   at Samp.Infrastructure.Services.SecurityRepository.UserHasAccessToReport(String userName, Guid reportId) in C:\@Sample\projects\samp\src\Infrastructure\Services\SecurityRepository.cs:line 51
   at Samp.Web.Helpers.ReportAccessProvider.Authenticate(HttpContextBase context) in C:\@Sample\projects\samp\src\Web\Helpers\ReportAccessProvider.cs:line 35
   at Samp.Web.Helpers.VerifyReportAccess.OnActionExecuting(ActionExecutingContext filterContext) in C:\@Sample\projects\samp\src\Web\Helpers\VerifyReportAccess.cs:line 13
   at System.Web.Mvc.ControllerActionInvoker.InvokeActionMethodFilter(IActionFilter filter, ActionExecutingContext preContext, Func`1 continuation)
   at System.Web.Mvc.ControllerActionInvoker.InvokeActionMethodFilter(IActionFilter filter, ActionExecutingContext preContext, Func`1 continuation)
   at System.Web.Mvc.ControllerActionInvoker.InvokeActionMethodWithFilters(ControllerContext controllerContext, IList`1 filters, ActionDescriptor actionDescriptor, IDictionary`2 parameters)
   at System.Web.Mvc.ControllerActionInvoker.InvokeAction(ControllerContext controllerContext, String actionName)
   at System.Web.Mvc.Controller.ExecuteCore()
   at System.Web.Mvc.ControllerBase.Execute(RequestContext requestContext)
   at System.Web.Mvc.MvcHandler.<>c__DisplayClass6.<>c__DisplayClassb.<BeginProcessRequest>b__5()
   at System.Web.Mvc.Async.AsyncResultWrapper.<>c__DisplayClass1.<MakeVoidDelegate>b__0()
   at System.Web.Mvc.MvcHandler.<>c__DisplayClasse.<EndProcessRequest>b__d()
   at System.Web.HttpApplication.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()
   at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& completedSynchronously)
```
