### PR TITLE
Replace column names that conflict with CSharp keywords automatically

### DIFF
--- a/PetaPoco/Models/Generated/PetaPoco.Core.ttinclude
+++ b/PetaPoco/Models/Generated/PetaPoco.Core.ttinclude
@@ -163,8 +163,18 @@ static Regex rxCleanUp = new Regex(@"[^\w\d_]", RegexOptions.Compiled);
 
 static Func<string, string> CleanUp = (str) =>
 {
+	string[] kws = { "abstract", "event", "new", "struct", "as", "explicit", "null", 
+	 "switch", "base", "extern", "object", "this", "bool", "false", "operator", "throw", 
+	 "break", "finally", "out", "true", "byte", "fixed", "override", "try", "case", "float", 
+	 "params", "typeof", "catch", "for", "private", "uint", "char", "foreach", "protected", 
+	 "ulong", "checked", "goto", "public", "unchecked", "class", "if", "readonly", "unsafe", 
+	 "const", "implicit", "ref", "ushort", "continue", "in", "return", "using", "decimal", 
+	 "int", "sbyte", "virtual", "default", "interface", "sealed", "volatile", "delegate", 
+	 "internal", "short", "void", "do", "is", "sizeof", "while", "double", "lock", 
+	 "stackalloc", "else", "long", "static", "enum", "namespace", "string" };
 	str = rxCleanUp.Replace(str, "_");
 	if (char.IsDigit(str[0])) str = "_" + str;
+	if(kws.Contains(str)) str = str + "_kwr";
 	
     return str;
 };


### PR DESCRIPTION
When generating models from legacy databases I often see column names that conflict with C# keywords. Since keywords cannot be property names the build will fail when this happens. Currently to correct this the options are to rename the column name in the database or manually updating the database.tt file with a series of tables["tablename"]["columnname"].Ignore or .PropertyName = "Non-ConflictingName" annotations.

To address this I added a check in the CleanUp function to replace C# keywords by appending "_kwr" to the property names when a match is found. _kwr is for KeyWord Replacement, but this could be any arbitrary string. 

While it is unlikely that we will see tables with column names such as uint or stackalloc, words such as operator, event, default, private and interface seem to come up all the time.
