### PR TITLE
Add support for datetimeoffset, nullable enums, and non-integer backed enums.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,49 @@
+﻿*.doc  diff=astextplain
+*.DOC	diff=astextplain
+*.docx	diff=astextplain
+*.DOCX	diff=astextplain
+*.dot	diff=astextplain
+*.DOT	diff=astextplain
+*.pdf	diff=astextplain
+*.PDF	diff=astextplain
+*.rtf	diff=astextplain
+*.RTF	diff=astextplain
+
+*.jpg  	binary
+*.png 	binary
+*.gif 	binary
+
+*.cs text=auto diff=csharp 
+*.vb text=auto
+*.c text=auto
+*.cpp text=auto
+*.cxx text=auto
+*.h text=auto
+*.hxx text=auto
+*.py text=auto
+*.rb text=auto
+*.java text=auto
+*.html text=auto
+*.htm text=auto
+*.css text=auto
+*.scss text=auto
+*.sass text=auto
+*.less text=auto
+*.js text=auto
+*.lisp text=auto
+*.clj text=auto
+*.sql text=auto
+*.php text=auto
+*.lua text=auto
+*.m text=auto
+*.asm text=auto
+*.erl text=auto
+*.fs text=auto
+*.fsx text=auto
+*.hs text=auto
+
+*.csproj text=auto merge=union 
+*.vbproj text=auto merge=union 
+*.fsproj text=auto merge=union 
+*.dbproj text=auto merge=union 
+*.sln text=auto eol=crlf merge=union 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-bin
+﻿bin
 obj
 *.suo
 *.nupkg
+*.ncrunchsolution
 

--- a/PetaPoco/Models/Generated/PetaPoco.Core.ttinclude
+++ b/PetaPoco/Models/Generated/PetaPoco.Core.ttinclude
@@ -593,10 +593,14 @@ class SqlServerSchemaReader : SchemaReader
 				 break;
 			case "smalldatetime":
 			case "datetime":
+			case "datetime2":
 			case "date":
 			case "time":
 				sysType=  "DateTime";
 				  break;
+			case "datetimeoffset":
+				sysType = "DateTimeOffset";
+				 break;
 			case "float":
 				sysType="double";
 				break;

--- a/PetaPoco/PetaPoco.cs
+++ b/PetaPoco/PetaPoco.cs
@@ -2094,11 +2094,19 @@ namespace PetaPoco
 				// Forced type conversion including integral types -> enum
 				if (converter == null)
 				{
+					var underlyingType = Nullable.GetUnderlyingType(dstType);
 					if (dstType.IsEnum && IsIntegralType(srcType))
 					{
 						if (srcType != typeof(int))
 						{
-							converter = delegate(object src) { return Convert.ChangeType(src, typeof(int), null); };
+							converter = delegate(object src) { return Enum.ToObject(dstType, src); };
+						}
+					}
+					else if (underlyingType != null && underlyingType.IsEnum && IsIntegralType(srcType))
+					{
+						if (srcType != typeof(int))
+						{
+							converter = delegate(object src) { return Enum.ToObject(underlyingType, src); };
 						}
 					}
 					else if (!dstType.IsAssignableFrom(srcType))


### PR DESCRIPTION
If you have a column with type datetimeoffset, it will just be mapped to a string in the T4 template. This fixes it to map to the DateTimeOffset CLR type. Also fixes datetime2 to be mapped to DateTime.

Also add support for nullable enums and non-integer backed enums as your POCO datatypes.