### PR TITLE
Output parameters bug fixed - (only with named parameters)

### DIFF
--- a/PetaPoco/PetaPoco.cs
+++ b/PetaPoco/PetaPoco.cs
@@ -381,6 +381,12 @@ namespace PetaPoco
 					}
 					return sb.ToString();
 				}
+				else if (arg_val is IDataParameter)
+		                {
+		                    if (!args_dest.Contains(arg_val))
+		                        args_dest.Add(arg_val);
+		                    return ((IDataParameter) arg_val).ParameterName;
+		                }
 				else
 				{
 					args_dest.Add(arg_val);
@@ -405,7 +411,6 @@ namespace PetaPoco
 			var idbParam = item as IDbDataParameter;
 			if (idbParam != null)
 			{
-				idbParam.ParameterName = string.Format("{0}{1}", ParameterPrefix, cmd.Parameters.Count);
 				cmd.Parameters.Add(idbParam);
 				return;
 			}


### PR DESCRIPTION
Allows petapoco to manage repeated occurrences of an output parameter in a sql statement
For example the following code was not supported:
private static void TestOutputParamNoSP()
{
            var param = new SqlParameter("@p", SqlDbType.Int);
            var i = 0;
            param.Direction = ParameterDirection.Output;
            PetaPocoTestsDB.GetInstance().Execute(@"
SET @i= @i + 58
set @p = @i + 15
set @p = @p* 2
", new { i, p = param });
            Console.WriteLine("Output param value={0}", param.Value);
        }