### PR TITLE
Accept connectionString (not name) and providerName in generated constructor

### DIFF
--- a/PetaPoco/Models/Generated/PetaPoco.Generator.ttinclude
+++ b/PetaPoco/Models/Generated/PetaPoco.Generator.ttinclude
@@ -27,6 +27,12 @@ namespace <#=Namespace #>
 			CommonConstruct();
 		}
 		
+		public <#=RepoName#>(string connectionString, string providerName) 
+			: base(connectionString, providerName)
+		{
+			CommonConstruct();
+		}
+
 		partial void CommonConstruct();
 		
 		public interface IFactory


### PR DESCRIPTION
Allows initialization using a connectionString (not a name) and provider. Handy for situations where the connectionString must be constructed at runtime.