### PR TITLE
Generation of MySQL objects scoped to active database

### DIFF
--- a/PetaPoco/Models/Generated/PetaPoco.Core.ttinclude
+++ b/PetaPoco/Models/Generated/PetaPoco.Core.ttinclude
@@ -1133,7 +1133,7 @@ class MySqlSchemaReader : SchemaReader
 	const string TABLE_SQL=@"
 			SELECT * 
 			FROM information_schema.tables 
-			WHERE (table_type='BASE TABLE' OR table_type='VIEW')
+			WHERE (table_type='BASE TABLE' OR table_type='VIEW') and TABLE_SCHEMA=database()
 			";
 
 }


### PR DESCRIPTION
When generation objects from a MySQL database, the selection of objects scopes to only objects from the current or specified (in Database.tt) schema name.