### PR TITLE
Default values from SQL columns

### DIFF
--- a/PetaPoco/Models/Generated/PetaPoco.Core.ttinclude
+++ b/PetaPoco/Models/Generated/PetaPoco.Core.ttinclude
@@ -135,6 +135,7 @@ public class Column
     public bool IsNullable;
 	public bool IsAutoIncrement;
 	public bool Ignore;
+    public string DefaultSetting;
 }
 
 public class Tables : List<Table>
@@ -538,6 +539,15 @@ class SqlServerSchemaReader : SchemaReader
 					col.PropertyType=GetPropertyType(rdr["DataType"].ToString());
 					col.IsNullable=rdr["IsNullable"].ToString()=="YES";
 					col.IsAutoIncrement=((int)rdr["IsIdentity"])==1;
+
+					//Stuart Pittaway added in DefaultSetting parameter for SQL Server type default values
+					col.DefaultSetting=rdr["DefaultSetting"].ToString();
+					while (col.DefaultSetting.StartsWith("(")) {col.DefaultSetting=col.DefaultSetting.Substring(1);}
+					while (col.DefaultSetting.EndsWith(")")) {col.DefaultSetting=col.DefaultSetting.Substring(0,col.DefaultSetting.Length-1);}
+					if (col.DefaultSetting.StartsWith("'")) col.DefaultSetting="\""+col.DefaultSetting.Substring(1);
+					if (col.DefaultSetting.EndsWith("'")) col.DefaultSetting=col.DefaultSetting.Substring(0,col.DefaultSetting.Length-1)+"\"";
+
+
 					result.Add(col);
 				}
 			}
@@ -730,6 +740,14 @@ class SqlServerCeSchemaReader : SchemaReader
 					col.PropertyType=GetPropertyType(rdr["DataType"].ToString());
 					col.IsNullable=rdr["IsNullable"].ToString()=="YES";
 					col.IsAutoIncrement=rdr["AUTOINC_INCREMENT"]!=DBNull.Value;
+
+					//Stuart Pittaway added in DefaultSetting parameter for SQL Server type default values
+					col.DefaultSetting=rdr["DefaultSetting"].ToString();
+					while (col.DefaultSetting.StartsWith("(")) {col.DefaultSetting=col.DefaultSetting.Substring(1);}
+					while (col.DefaultSetting.EndsWith(")")) {col.DefaultSetting=col.DefaultSetting.Substring(0,col.DefaultSetting.Length-1);}
+					if (col.DefaultSetting.StartsWith("'")) col.DefaultSetting="\""+col.DefaultSetting.Substring(1);
+					if (col.DefaultSetting.EndsWith("'")) col.DefaultSetting=col.DefaultSetting.Substring(0,col.DefaultSetting.Length-1)+"\"";
+
 					result.Add(col);
 				}
 			}

--- a/PetaPoco/Models/Generated/PetaPoco.Generator.ttinclude
+++ b/PetaPoco/Models/Generated/PetaPoco.Generator.ttinclude
@@ -10,7 +10,10 @@ using System.Linq;
 using System.Web;
 using PetaPoco;
 
+// ReSharper disable InconsistentNaming
+// ReSharper disable CheckNamespace
 namespace <#=Namespace #>
+// ReSharper restore CheckNamespace
 {
 <# if (GenerateCommon) { #>
 	public partial class <#=RepoName#> : Database
@@ -151,6 +154,30 @@ foreach(Table tbl in from t in tables where !t.Ignore select t)
 	[ExplicitColumns]
     public partial class <#=tbl.ClassName#> <# if (GenerateOperations) { #>: <#=RepoName#>.Record<<#=tbl.ClassName#>> <# } #> 
     {
+
+	public <#=tbl.ClassName#>(){
+//Stuarts Auto Generated Class Initaliser for Default values
+<#
+foreach(Column col in from c in tbl.Columns where !c.Ignore select c)
+{
+// Columns for default values
+#>
+<# if ((col.DefaultSetting!=null) && (col.DefaultSetting.Length>0))  {#>
+<# if (col.PropertyType=="DateTime" && col.DefaultSetting=="0") {
+//Issues with ZERO being returned for default value for DateTime in SQL Server column, this
+//should be defaulted to 1900-01-01
+#>
+	//Default datetime (cast INT zero to SQL Server DATETIME datatype 1900-01-01 00:00:00.000)
+	this.<#=col.PropertyName #> = DateTime.FromBinary(599266080000000000L);
+<#} else {#>
+	this.<#=col.PropertyName #> = <#=col.DefaultSetting#>;
+<# } #>
+<# } #>
+<# } #>
+}
+
+<#
+
 <#
 foreach(Column col in from c in tbl.Columns where !c.Ignore select c)
 {
@@ -188,3 +215,4 @@ foreach(Column col in from c in tbl.Columns where !c.Ignore select c)
 <# } #>
 <# } #>
 }
+// ReSharper restore InconsistentNaming


### PR DESCRIPTION
Hello, I've modified the T4 code to automatically generate constructor classes and init the field values based on the database columns.

The problem I was getting was when working with existing tables (with many hundreds of columns) but only wanting to insert a few column values.

This change prevents me having to manually set each field in my code.

Regards

Stuart.