### PR TITLE
Add decimal primary key

### DIFF
--- a/PetaPoco/PetaPoco.cs
+++ b/PetaPoco/PetaPoco.cs
@@ -1570,7 +1570,9 @@ namespace PetaPoco
 					return (int)pk == 0;
 				else if (type == typeof(uint))
 					return (uint)pk == 0;
-
+				else if( type == typeof( decimal ) ) // adding a decimal type primary key
+					return (decimal)pk == 0;
+					
 				// Create a default instance and compare
 				return pk == Activator.CreateInstance(pk.GetType());
 			}


### PR DESCRIPTION
I have several databases with the decimal type as it's primary key. It originally had to do due with SQL Server 6.5's lack of a bigint data type and has been long carved in stone.

I end up patching it every time I look for an update and and am submitting it in the hope that it will help someone else too.

Thanks!