### PR TITLE
Only mark column as modified if it is a different value.

### DIFF
--- a/PetaPoco/Models/Generated/PetaPoco.Generator.ttinclude
+++ b/PetaPoco/Models/Generated/PetaPoco.Generator.ttinclude
@@ -170,8 +170,11 @@ foreach(Column col in from c in tbl.Columns where !c.Ignore select c)
 			}
 			set
 			{
-				_<#=col.PropertyName #> = value;
-				MarkColumnModified("<#=col.Name#>");
+				if (value != _<#=col.PropertyName #>)
+				{
+					_<#=col.PropertyName #> = value;
+					MarkColumnModified("<#=col.Name#>");
+				}
 			}
 		}
 		<#=col.PropertyType #><#=CheckNullable(col)#> _<#=col.PropertyName #>;


### PR DESCRIPTION
Before setting the property with the value check to see if it is really
an updated value.
When it is take the value and then call MarkColumnModified.