### PR TITLE
Adds support for specifying isolation level both globally and at the transaction level. v5

### DIFF
--- a/PetaPoco/Core/Transaction.cs
+++ b/PetaPoco/Core/Transaction.cs
@@ -2,6 +2,7 @@
 // Copyright © 2011-2012 Topten Software.  All Rights Reserved.
  
 using System;
+using System.Data;
 
 namespace PetaPoco
 {
@@ -18,8 +19,14 @@ namespace PetaPoco
 		public Transaction(Database db)
 		{
 			_db = db;
-			_db.BeginTransaction();
+			_db.BeginTransaction(db.DefaultIsolationLevel);
 		}
+
+        public Transaction(Database db, IsolationLevel isolationLevel)
+        {
+            _db = db;
+            _db.BeginTransaction(isolationLevel);
+        }
 
 		public void Complete()
 		{

--- a/PetaPoco/Database.cs
+++ b/PetaPoco/Database.cs
@@ -233,6 +233,32 @@ namespace PetaPoco
 			return new Transaction(this);
 		}
 
+        /// <summary>
+        /// Starts or continues a transaction with a specific isolation level.
+        /// </summary>
+        /// <returns>An ITransaction reference that must be Completed or disposed</returns>
+        /// <remarks>
+        /// This method makes management of calls to Begin/End/CompleteTransaction easier.  
+        /// 
+        /// The usage pattern for this should be:
+        /// 
+        /// using (var tx = db.GetTransaction())
+        /// {
+        ///		// Do stuff
+        ///		db.Update(...);
+        ///		
+        ///     // Mark the transaction as complete
+        ///     tx.Complete();
+        /// }
+        /// 
+        /// Transactions can be nested but they must all be completed otherwise the entire
+        /// transaction is aborted.
+        /// </remarks>
+        public ITransaction GetTransaction(IsolationLevel isolationLevel)
+        {
+            return new Transaction(this, isolationLevel);
+        }
+
 		/// <summary>
 		/// Called when a transaction starts.  Overridden by the T4 template generated database
 		/// classes to ensure the same DB instance is used throughout the transaction.
@@ -251,14 +277,14 @@ namespace PetaPoco
 		/// <summary>
 		/// Starts a transaction scope, see GetTransaction() for recommended usage
 		/// </summary>
-		public void BeginTransaction()
+		public void BeginTransaction(IsolationLevel isolationLevel)
 		{
 			_transactionDepth++;
 
 			if (_transactionDepth == 1)
 			{
 				OpenSharedConnection();
-				_transaction = _sharedConnection.BeginTransaction();
+				_transaction = _sharedConnection.BeginTransaction(isolationLevel);
 				_transactionCancelled = false;
 				OnBeginTransaction();
 			}
@@ -2072,6 +2098,15 @@ namespace PetaPoco
 			get; 
 			set; 
 		}
+
+        /// <summary>
+        /// Sets the default isolation level for all transactions.
+        /// </summary>
+        public IsolationLevel DefaultIsolationLevel
+        {
+            get;
+            set;
+        }
 		#endregion
 
 		#region Member Fields

--- a/PetaPoco/Database.cs
+++ b/PetaPoco/Database.cs
@@ -113,6 +113,7 @@ namespace PetaPoco
 			_transactionDepth = 0;
 			EnableAutoSelect = true;
 			EnableNamedParams = true;
+            DefaultIsolationLevel = IsolationLevel.ReadCommitted;
 
 			// If a provider name was supplied, get the IDbProviderFactory for it
 			if (_providerName != null)


### PR DESCRIPTION
So in [this StackOverflow question](http://stackoverflow.com/questions/19862748/petapoco-setting-transaction-isolation-level), I asked about the possibility of specifying an isolation level for transactions while using PetaPoco. Since it looked like - at least on initial glance - there wasn't any way to do this without actually prepending `"SET TRANSACTION LEVEL [LEVEL]"` before each query, I added in a way to specify isolation level.

At the transaction level:

```csharp
var newObject = new NewObject();
var newObjectId = 1;
using (var scope = db.GetTransaction(IsolationLevel.ReadUncommitted))
{
    newObject = db.SingleOrDefault<NewObject>("SELECT * FROM tblNewObject WHERE Id = @0", newObjectId);
    scope.Complete();
}
```

...and at the database level (specifically, in this case, using Autofac as the IoC):

```csharp
builder.Register(a => new PetaPoco.Database("connectionStringName") { DefaultIsolationLevel = IsolationLevel.ReadUncommitted }).As<PetaPoco.Database>().InstancePerLifetimeScope();
```

I would like to expand out to being able to provide an isolation for the LINQ-esque methods without having to explicitly manage transactions, but without further examination of the source, I can't determine whether or not that would have adverse effects. For now, I think this is a good way to be able to provide some level of transaction isolation control.