### PR TITLE
Added support for DBNull in ExecuteScalar

### DIFF
--- a/PetaPoco/Database.cs
+++ b/PetaPoco/Database.cs
@@ -562,7 +562,7 @@ namespace PetaPoco
 
 						// Handle nullable types
 						Type u = Nullable.GetUnderlyingType(typeof(T));
-						if (u != null && val == null) 
+						if (u != null && (val == null || val == DBNull.Value)) 
 							return default(T);
 
 						return (T)Convert.ChangeType(val, u==null ? typeof(T) : u);


### PR DESCRIPTION
If SqlCommand.ExecuteScalar() returns DBNull.Value and the return type T of ExecuteScalar<T> is nullable, an InvalidCastException is thrown.
This patch handles DBNull.Value the same way as null.

This happens for example if ExecuteScalar<int?>("SELECT MAX(id) FROM empty_table") is queried on an empty table.