### PR TITLE
Additional query support and a null reference guard

### DIFF
--- a/PetaPoco/Database.cs
+++ b/PetaPoco/Database.cs
@@ -430,7 +430,7 @@ namespace PetaPoco
             {
                 p.Value = DBNull.Value;
 
-                if (pi.PropertyType.Name == "Byte[]")
+                if ((pi != null) && (pi.PropertyType.Name == "Byte[]"))
                 {
                     p.DbType = DbType.Binary;
                 }

--- a/PetaPoco/Utilities/AutoSelectHelper.cs
+++ b/PetaPoco/Utilities/AutoSelectHelper.cs
@@ -12,7 +12,7 @@ namespace PetaPoco.Internal
 {
     internal static class AutoSelectHelper
     {
-        private static Regex rxSelect = new Regex(@"\A\s*(SELECT|EXECUTE|CALL)\s",
+        private static Regex rxSelect = new Regex(@"\A\s*(SELECT|EXECUTE|CALL|WITH|SET)\s",
             RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Multiline);
 
         private static Regex rxFrom = new Regex(@"\A\s*FROM\s",


### PR DESCRIPTION
Two minor changes:

1. added support for queries with custom sql, starting with the `WITH` or `SET` keyword;
2. added a null reference guard to the propertyinfo in the AddParam method;
