### PR TITLE
Fixes issue where internal properties aren't populated

### DIFF
--- a/PetaPoco/Core/PocoData.cs
+++ b/PetaPoco/Core/PocoData.cs
@@ -46,7 +46,7 @@ namespace PetaPoco.Core
 
             // Work out bound properties
             Columns = new Dictionary<string, PocoColumn>(StringComparer.OrdinalIgnoreCase);
-            foreach (var pi in type.GetProperties())
+            foreach (var pi in type.GetProperties(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public))
             {
                 ColumnInfo ci = mapper.GetColumnInfo(pi);
                 if (ci == null)


### PR DESCRIPTION
This is a proposed fix for #261 . I believe this to be a regression, given that other versions of PetaPoco I've used have been capable of populating internal types