### PR TITLE
Fix for AnsiString 

### DIFF
--- a/PetaPoco/Database.cs
+++ b/PetaPoco/Database.cs
@@ -466,6 +466,11 @@ namespace PetaPoco
                     p.Size = Math.Max((value as AnsiString).Value.Length + 1, 4000);
                     p.Value = (value as AnsiString).Value;
                     p.DbType = DbType.AnsiString;
+                    if(p is System.Data.SqlClient.SqlParameter)
+                    {
+                        var cast = p as System.Data.SqlClient.SqlParameter;
+                        cast.SqlDbType = SqlDbType.VarChar;
+                    }
                 }
                 else if (value.GetType().Name == "SqlGeography") //SqlGeography is a CLR Type
                 {


### PR DESCRIPTION
When using AnsiString, the param is still passed as a nvarchar.
Setting the SqlDbType fixes this issue

This is when using PetaPoco 5.1.153 and MS Sql Server 2012 (11.0.6020)
