### PR TITLE
Fix for guid to string conversion issue; #285

### DIFF
--- a/PetaPoco/Core/PocoData.cs
+++ b/PetaPoco/Core/PocoData.cs
@@ -363,6 +363,10 @@ namespace PetaPoco.Core
                 {
                     return delegate(object src) { return Guid.Parse((string) src); };
                 }
+                else if (dstType == typeof(string) && srcType == typeof(Guid))
+                {
+                    return delegate(object src) { return Convert.ToString(src); };
+                }
                 else
                 {
                     return delegate(object src) { return Convert.ChangeType(src, dstType, null); };


### PR DESCRIPTION
Proposed fix for issue I submitted earlier today [https://github.com/CollaboratingPlatypus/PetaPoco/issues/285](url)

This is pretty straight forward just adds explicit conversion from Guid to string. Guid does not implement IConvertible so the else clause currently results in an exception. This is mostly applicable to Sql Server where uniqueidentifiers are mapped to guids by SqlClient but are often much easier to treat as strings.
