### PR TITLE
Fixing byte based enums

### DIFF
--- a/PetaPoco/Database.cs
+++ b/PetaPoco/Database.cs
@@ -443,7 +443,7 @@ namespace PetaPoco
                 var t = value.GetType();
                 if (t.IsEnum) // PostgreSQL .NET driver wont cast enum to int
                 {
-                    p.Value = (int) value;
+                    p.Value = Convert.ChangeType(value, ((Enum)value).GetTypeCode());
                 }
                 else if (t == typeof(Guid) && !_provider.HasNativeGuidSupport)
                 {


### PR DESCRIPTION
If your enum is based on byte type, peta poco fails on casting. JCKodel's solution works well, 
https://github.com/CollaboratingPlatypus/PetaPoco/issues/126