### PR TITLE
Pynej patch 1

### DIFF
--- a/PetaPoco/T4 Templates/Database.tt
+++ b/PetaPoco/T4 Templates/Database.tt
@@ -10,6 +10,7 @@
 	ClassPrefix = "";
 	ClassSuffix = "";
 	TrackModifiedColumns = false;
+	ExcludePrefix = new string[] {}; // Exclude tables by prefix.
 
     // Read schema
 	var tables = LoadTables();

--- a/PetaPoco/T4 Templates/PetaPoco.Core.ttinclude
+++ b/PetaPoco/T4 Templates/PetaPoco.Core.ttinclude
@@ -90,6 +90,7 @@ bool GenerateOperations = false;
 bool GenerateCommon = true;
 bool GeneratePocos = true;
 bool TrackModifiedColumns = false;
+string[] ExcludePrefix = new string[] {};
 
 
 public class Table
@@ -418,6 +419,10 @@ Tables LoadTables()
 					result.RemoveAt(i);
 					continue;
 				}
+				if(StartsWithAny(result[i].ClassName, ExcludePrefix)) {
+					result.RemoveAt(i);
+					continue;
+				}
 			}
 
 			conn.Close();
@@ -453,6 +458,14 @@ Tables LoadTables()
 	}
 
         
+}
+
+bool StartsWithAny(string s, IEnumerable<string> items)
+{
+    if (s == null)
+        return false;
+
+    return items.Any(i => s.StartsWith(i));
 }
 
 abstract class SchemaReader


### PR DESCRIPTION
This is a simple addition of a Exclude by Prefix variable that can be used to supress a block of tables from being generated.  

It may work better to add this as a Regex instead but the above was all my project neeed.
Eg: 
``ExcludeTablesRegex = "^(cms|CMS|umbraco).*$";``
Or maybe even a ovverride to included only matched tables instead of defaulting to all.
``IncludeTablesRegex = "myPrefix.*";``