### PR TITLE
Update PetaPoco.Core.ttinclude to support Guid auto-generation in SQL

### DIFF
--- a/PetaPoco/T4 Templates/PetaPoco.Core.ttinclude
+++ b/PetaPoco/T4 Templates/PetaPoco.Core.ttinclude
@@ -563,7 +563,9 @@ class SqlServerSchemaReader : SchemaReader
 					col.PropertyName=CleanUp(col.Name);
 					col.PropertyType=GetPropertyType(rdr["DataType"].ToString());
 					col.IsNullable=rdr["IsNullable"].ToString()=="YES";
-					col.IsAutoIncrement=((int)rdr["IsIdentity"])==1;
+					col.IsAutoIncrement=((int)rdr["IsIdentity"])==1 || 
+							(!DBNull.Value.Equals(rdr["DefaultSetting"]) && ((string)rdr["DefaultSetting"] == "(newsequentialid())" ||
+							(string)rdr["DefaultSetting"] == "(newid())"));
 					result.Add(col);
 				}
 			}


### PR DESCRIPTION
Fixed auto-increment for Guid key when its default value is set in SQL server as newsequentialid() or newid().

Here is the case:
Insert a record into a table with primary key is Guid and its default value is newsquentialid() or newid().

Fix for the issue #305 