### PR TITLE
Provider factories docs - update npgsql driver version to current 3.2…

### DIFF
--- a/PetaPoco/T4 Templates/PetaPoco.Core.ttinclude
+++ b/PetaPoco/T4 Templates/PetaPoco.Core.ttinclude
@@ -41,6 +41,10 @@
  using Visual Studio 2010 the file you want is here:
 
 	C:\Windows\Microsoft.NET\Framework\v4.0.30319\Config\machine.config
+	
+ If you are using VS2015 or VS2017 you may also need to update machine.config file located here:
+
+	C:\Windows\Microsoft.NET\Framework64\v4.0.30319\Config\machine.config
 
  After making changes to machine.config you will also need to restart Visual Studio.
 
@@ -54,7 +58,7 @@
 			<add name="SqlClient Data Provider" invariant="System.Data.SqlClient" description=".Net Framework Data Provider for SqlServer" type="System.Data.SqlClient.SqlClientFactory, System.Data, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
 			<add name="MySQL Data Provider" invariant="MySql.Data.MySqlClient" description=".Net Framework Data Provider for MySQL" type="MySql.Data.MySqlClient.MySqlClientFactory, MySql.Data, Version=6.3.4.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d"/>
 			<add name="Microsoft SQL Server Compact Data Provider" invariant="System.Data.SqlServerCe.3.5" description=".NET Framework Data Provider for Microsoft SQL Server Compact" type="System.Data.SqlServerCe.SqlCeProviderFactory, System.Data.SqlServerCe, Version=3.5.1.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91"/><add name="Microsoft SQL Server Compact Data Provider 4.0" invariant="System.Data.SqlServerCe.4.0" description=".NET Framework Data Provider for Microsoft SQL Server Compact" type="System.Data.SqlServerCe.SqlCeProviderFactory, System.Data.SqlServerCe, Version=4.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91"/>
-			<add name="Npgsql Data Provider" invariant="Npgsql" support="FF" description=".Net Framework Data Provider for Postgresql Server" type="Npgsql.NpgsqlFactory, Npgsql, Version=2.0.11.91, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7" />
+			<add name="Npgsql" invariant="Npgsql" description=".NET Data Provider for PostgreSQL" type="Npgsql.NpgsqlFactory, Npgsql, Version=3.2.2.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7"/>
 		</DbProviderFactories>
 	</system.data>
 
@@ -64,6 +68,7 @@
 
 	 gacutil /i Npgsql.dll
 	 gacutil /i Mono.Security.dll
+	 gacutil /i System.Threading.Tasks.Extensions.dll
 
  -----------------------------------------------------------------------------------------
  


### PR DESCRIPTION
Minor docs changes making Npgsql use for VS2015 and VS2017 easier by default
- added info on update machine.config in Framework64
- updated Npgsql factory assembly version to current (3.2.2.0) 
- added info on install System.Threading.Tasks.Extensions.dll to GAC
