### PR TITLE
Move Database helper methods to DatabaseProvider

### DIFF
--- a/PetaPoco/Core/DatabaseProvider.cs
+++ b/PetaPoco/Core/DatabaseProvider.cs
@@ -153,7 +153,7 @@ namespace PetaPoco.Core
         public virtual object ExecuteInsert(Database database, IDbCommand cmd, string primaryKeyName)
         {
             cmd.CommandText += ";\nSELECT @@IDENTITY AS NewID;";
-            return database.ExecuteScalarHelper(cmd);
+            return ExecuteScalarHelper(database, cmd);
         }
 
         /// <summary>
@@ -276,5 +276,22 @@ namespace PetaPoco.Core
             var unwrapped = sp.GetService(factory.GetType()) as DbProviderFactory;
             return unwrapped == null ? factory : Unwrap(unwrapped);
         }
+
+        protected void ExecuteNonQueryHelper(Database db, IDbCommand cmd)
+        {
+            db.DoPreExecute(cmd);
+            cmd.ExecuteNonQuery();
+            db.OnExecutedCommand(cmd);
+        }
+
+        protected object ExecuteScalarHelper(Database db, IDbCommand cmd)
+        {
+            db.DoPreExecute(cmd);
+            object r = cmd.ExecuteScalar();
+            db.OnExecutedCommand(cmd);
+            return r;
+        }
+
+
     }
 }

--- a/PetaPoco/Database.cs
+++ b/PetaPoco/Database.cs
@@ -2482,21 +2482,6 @@ namespace PetaPoco
 
         #region Internal operations
 
-        internal void ExecuteNonQueryHelper(IDbCommand cmd)
-        {
-            DoPreExecute(cmd);
-            cmd.ExecuteNonQuery();
-            OnExecutedCommand(cmd);
-        }
-
-        internal object ExecuteScalarHelper(IDbCommand cmd)
-        {
-            DoPreExecute(cmd);
-            object r = cmd.ExecuteScalar();
-            OnExecutedCommand(cmd);
-            return r;
-        }
-
         internal void DoPreExecute(IDbCommand cmd)
         {
             // Setup command timeout

--- a/PetaPoco/Providers/FirebirdDbDatabaseProvider.cs
+++ b/PetaPoco/Providers/FirebirdDbDatabaseProvider.cs
@@ -34,7 +34,7 @@ namespace PetaPoco.Providers
                 cmd.CommandText = cmd.CommandText.Substring(0, cmd.CommandText.Length - 1);
 
             cmd.CommandText += " RETURNING " + EscapeSqlIdentifier(primaryKeyName) + ";";
-            return database.ExecuteScalarHelper(cmd);
+            return ExecuteScalarHelper(database, cmd);
         }
 
         public override string EscapeSqlIdentifier(string sqlIdentifier)

--- a/PetaPoco/Providers/MsAccessDbDatabaseProvider.cs
+++ b/PetaPoco/Providers/MsAccessDbDatabaseProvider.cs
@@ -21,9 +21,9 @@ namespace PetaPoco.Providers
 
         public override object ExecuteInsert(Database database, IDbCommand cmd, string primaryKeyName)
         {
-            database.ExecuteNonQueryHelper(cmd);
+            ExecuteNonQueryHelper(database, cmd);
             cmd.CommandText = "SELECT @@IDENTITY AS NewID;";
-            return database.ExecuteScalarHelper(cmd);
+            return ExecuteScalarHelper(database, cmd);
         }
 
         public override string BuildPageQuery(long skip, long take, SQLParts parts, ref object[] args)

--- a/PetaPoco/Providers/OracleDatabaseProvider.cs
+++ b/PetaPoco/Providers/OracleDatabaseProvider.cs
@@ -67,12 +67,12 @@ namespace PetaPoco.Providers
                 param.Direction = ParameterDirection.ReturnValue;
                 param.DbType = DbType.Int64;
                 cmd.Parameters.Add(param);
-                db.ExecuteNonQueryHelper(cmd);
+                ExecuteNonQueryHelper(db, cmd);
                 return param.Value;
             }
             else
             {
-                db.ExecuteNonQueryHelper(cmd);
+                ExecuteNonQueryHelper(db, cmd);
                 return -1;
             }
         }

--- a/PetaPoco/Providers/PostgreSQLDatabaseProvider.cs
+++ b/PetaPoco/Providers/PostgreSQLDatabaseProvider.cs
@@ -45,11 +45,11 @@ namespace PetaPoco.Providers
             if (primaryKeyName != null)
             {
                 cmd.CommandText += string.Format("returning {0} as NewID", EscapeSqlIdentifier(primaryKeyName));
-                return db.ExecuteScalarHelper(cmd);
+                return ExecuteScalarHelper(db, cmd);
             }
             else
             {
-                db.ExecuteNonQueryHelper(cmd);
+                ExecuteNonQueryHelper(db, cmd);
                 return -1;
             }
         }

--- a/PetaPoco/Providers/SQLiteDatabaseProvider.cs
+++ b/PetaPoco/Providers/SQLiteDatabaseProvider.cs
@@ -29,11 +29,11 @@ namespace PetaPoco.Providers
             if (primaryKeyName != null)
             {
                 cmd.CommandText += ";\nSELECT last_insert_rowid();";
-                return db.ExecuteScalarHelper(cmd);
+                return ExecuteScalarHelper(db, cmd);
             }
             else
             {
-                db.ExecuteNonQueryHelper(cmd);
+                ExecuteNonQueryHelper(db, cmd);
                 return -1;
             }
         }

--- a/PetaPoco/Providers/SqlServerCEDatabaseProviders.cs
+++ b/PetaPoco/Providers/SqlServerCEDatabaseProviders.cs
@@ -29,7 +29,7 @@ namespace PetaPoco.Providers
 
         public override object ExecuteInsert(Database db, System.Data.IDbCommand cmd, string primaryKeyName)
         {
-            db.ExecuteNonQueryHelper(cmd);
+            ExecuteNonQueryHelper(db, cmd);
             return db.ExecuteScalar<object>("SELECT @@@IDENTITY AS NewID;");
         }
     }

--- a/PetaPoco/Providers/SqlServerDatabaseProvider.cs
+++ b/PetaPoco/Providers/SqlServerDatabaseProvider.cs
@@ -44,7 +44,7 @@ namespace PetaPoco.Providers
 
         public override object ExecuteInsert(Database db, System.Data.IDbCommand cmd, string primaryKeyName)
         {
-            return db.ExecuteScalarHelper(cmd);
+            return ExecuteScalarHelper(db, cmd);
         }
 
         public override string GetExistsSql()


### PR DESCRIPTION
`Database` has two helper methods which are marked `internal` and which are only called by `DatabaseProvider` and descendants. Because they are `internal`, they cannot be called by `DatabaseProvider` descendants in other assemblies.  Move these helper methods to `DatabaseProvider` and mark as `protected`.

Addresses #428 