### PR TITLE
Null check in FromDbConverter and ToDbConverter

### DIFF
--- a/PetaPoco/Core/ConventionMapper.cs
+++ b/PetaPoco/Core/ConventionMapper.cs
@@ -157,16 +157,22 @@ namespace PetaPoco
             };
             FromDbConverter = (pi, t) =>
             {
-                var valueConverter = pi.GetCustomAttributes(typeof(ValueConverterAttribute), true).FirstOrDefault() as ValueConverterAttribute;
-                if (valueConverter != null)
-                    return valueConverter.ConvertFromDb;
+                if (pi != null)
+                {
+                    var valueConverter = pi.GetCustomAttributes(typeof(ValueConverterAttribute), true).FirstOrDefault() as ValueConverterAttribute;
+                    if (valueConverter != null)
+                        return valueConverter.ConvertFromDb;
+                }
                 return null;
             };
             ToDbConverter = (pi) =>
             {
-                var valueConverter = pi.GetCustomAttributes(typeof(ValueConverterAttribute), true).FirstOrDefault() as ValueConverterAttribute;
-                if (valueConverter != null)
-                    return valueConverter.ConvertToDb;
+                if (pi != null)
+                {
+                    var valueConverter = pi.GetCustomAttributes(typeof(ValueConverterAttribute), true).FirstOrDefault() as ValueConverterAttribute;
+                    if (valueConverter != null)
+                        return valueConverter.ConvertToDb;
+                }
                 return null;
             };
         }


### PR DESCRIPTION
Support for value converter attribute in #408 appears to be missing two null checks in code added to `ConventionMapper.cs`. This was causing queries into `dynamic` objects to throw an exception, as reported in #415 and #430.

I added the null checks, and the examples in the referenced issues work fine now. All existing unit tests also pass. Possibly some further testing is needed before releasing.