### PR TITLE
Exists Parameter support entity objects

### DIFF
--- a/PetaPoco/Database.cs
+++ b/PetaPoco/Database.cs
@@ -1048,7 +1048,8 @@ namespace PetaPoco
         /// <returns>True if a record with the specified primary key value exists.</returns>
         public bool Exists<T>(object primaryKey)
         {
-            return Exists<T>(string.Format("{0}=@0", _provider.EscapeSqlIdentifier(PocoData.ForType(typeof(T), _defaultMapper).TableInfo.PrimaryKey)), primaryKey);
+            var poco = PocoData.ForType(typeof(T), _defaultMapper);
+            return Exists<T>(string.Format("{0}=@0", _provider.EscapeSqlIdentifier(poco.TableInfo.PrimaryKey)), primaryKey is T ? poco.Columns[poco.TableInfo.PrimaryKey].GetValue(primaryKey) : primaryKey);
         }
 
         #endregion


### PR DESCRIPTION
//The primary key is not using the save method when the self identification column is added.   

Examples:
 [TableName("dbo.Person")]
    [PrimaryKey("IdCard", AutoIncrement = false)]
    [ExplicitColumns]
    class Person
    {
        [Column] public string IdCard { get; set; }
        [Column] public string Name { get; set; }
    }

    var model = new Person() { IdCard = "1234567890", Name = "mayb" };
    var db = new Database();
    if (db.Exists<Person>(model)) db.Update(model);
    else db.Insert(model);