### PR TITLE
Add missing provider configuration step

### DIFF
--- a/PetaPoco/DatabaseConfigurationExtensions.cs
+++ b/PetaPoco/DatabaseConfigurationExtensions.cs
@@ -105,6 +105,7 @@ namespace PetaPoco
                 throw new ArgumentNullException("provider");
             if (configure == null)
                 throw new ArgumentNullException("configure");
+            configure(provider);
             source.SetSetting(Provider, provider);
             return source;
         }


### PR DESCRIPTION
The overload of `UsingProvider()` that takes a provider instance and a configuration callback does not actually use the callback.