### PR TITLE
Add methods to register and retrieve custom providers

### DIFF
--- a/PetaPoco.Tests.Unit/PetaPoco.Tests.Unit.csproj
+++ b/PetaPoco.Tests.Unit/PetaPoco.Tests.Unit.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Core\SqlTests.cs" />
     <Compile Include="DatabaseConfigurationTests.cs" />
     <Compile Include="DatabaseTests.cs" />
+    <Compile Include="Providers\CustomProviderRegistrationTests.cs" />
     <Compile Include="Providers\SqlServerDatabaseProviderTests.cs" />
     <Compile Include="DescriptionAttribute.cs" />
     <Compile Include="Models\Note.cs" />

--- a/PetaPoco.Tests.Unit/Providers/CustomProviderRegistrationTests.cs
+++ b/PetaPoco.Tests.Unit/Providers/CustomProviderRegistrationTests.cs
@@ -1,0 +1,110 @@
+﻿// <copyright company="PetaPoco - CollaboratingPlatypus">
+//      Apache License, Version 2.0 https://github.com/CollaboratingPlatypus/PetaPoco/blob/master/LICENSE.txt
+// </copyright>
+// <author>PetaPoco - CollaboratingPlatypus</author>
+// <date>2018/04/10</date>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Shouldly;
+using PetaPoco.Core;
+using System.Data.Common;
+using PetaPoco.Providers;
+using System.Data;
+
+namespace PetaPoco.Tests.Unit.Providers
+{
+    public class CustomProviderRegistrationTests: IDisposable
+    {
+        public void Dispose()
+        {
+            DatabaseProvider.ClearCustomProviders();            
+        }
+
+        private void RegisterProviders()
+        {
+            DatabaseProvider.RegisterCustomProvider<MyCustomProvider>("Foo");
+            DatabaseProvider.RegisterCustomProvider<MyCustomProvider>("Bar");
+        }
+
+        [Theory]
+        [InlineData("Foo", typeof(MyCustomProvider))]
+        [InlineData("foo", typeof(MyCustomProvider))]
+        [InlineData("FOO", typeof(MyCustomProvider))]
+        [InlineData("Bar", typeof(MyCustomProvider))]
+        [InlineData("Baz", typeof(SqlServerDatabaseProvider))]
+        [InlineData("MySql.SomethingOrOther", typeof(MySqlDatabaseProvider))]
+        public void Resolve_WithName_ShouldHaveExpectedProvider(string name, Type type)
+        {
+            RegisterProviders();
+            var provider = DatabaseProvider.Resolve(name, true, "Data Source=foo");
+            provider.GetType().ShouldBe(type);
+        }
+
+        [Theory]
+        [InlineData(typeof(FooType), typeof(MyCustomProvider))]
+        [InlineData(typeof(BarType), typeof(MyCustomProvider))]
+        [InlineData(typeof(String), typeof(SqlServerDatabaseProvider))]
+        [InlineData(typeof(MariaDbType), typeof(MariaDbDatabaseProvider))]
+        public void Resolve_WithType_ShouldHaveExpectedProvider(Type inputType, Type providerType)
+        {
+            RegisterProviders();
+            var provider = DatabaseProvider.Resolve(inputType, true, "Data Source=foo");
+            provider.GetType().ShouldBe(providerType);
+        }
+
+        [Fact]
+        public void ChangingRegistration_ShouldHaveExpectedProvider()
+        {
+            RegisterProviders();
+            DatabaseProvider.RegisterCustomProvider<MyOtherCustomProvider>("Foo");
+            var provider = DatabaseProvider.Resolve("foo", true, "Data Source=foo");
+            provider.GetType().ShouldBe(typeof(MyOtherCustomProvider));
+        }
+
+        [Fact]
+        public void NoCustomRegistrations_ShouldHaveDefaultProvider()
+        {
+            var provider = DatabaseProvider.Resolve("foo", true, "Data Source=foo");
+            provider.GetType().ShouldBe(typeof(SqlServerDatabaseProvider));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("  ")]
+        [InlineData(null)]
+        public void InvalidString_ShouldThrow(string input)
+        {
+            Should.Throw<ArgumentException>(() => DatabaseProvider.RegisterCustomProvider<MyCustomProvider>(input));
+        }
+
+
+
+
+        private class MyCustomProvider : DatabaseProvider
+        {
+            public override DbProviderFactory GetFactory()
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class MyOtherCustomProvider : DatabaseProvider
+        {
+            public override DbProviderFactory GetFactory()
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class FooType { }
+
+        private class BarType { }
+
+        private class MariaDbType { }
+    }
+}

--- a/PetaPoco.sln.DotSettings
+++ b/PetaPoco.sln.DotSettings
@@ -1,4 +1,8 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSOR_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_FIELD_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_SIMPLE_EMBEDDED_STATEMENT_ON_SAME_LINE/@EntryValue">NEVER</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SIMPLE_EMBEDDED_STATEMENT_STYLE/@EntryValue">LINE_BREAK</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_AROUND_MULTIPLICATIVE_OP/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_WITHIN_SINGLE_LINE_ARRAY_INITIALIZER_BRACES/@EntryValue">True</s:Boolean>
@@ -157,7 +161,12 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=DB/@EntryIndexedValue">DB</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=MS/@EntryIndexedValue">MS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpRenamePlacementToArrangementMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAlwaysTreatStructAsNotReorderableMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
Addresses #447 

This is a first pass at the sort of thing I had in mind; I'm interested to hear feedback. What I'm envisioning is that rather than the end user needing to know how to correctly register a custom provider (i.e., what initialStrings to use), the provider could just implement its own static `Register()` method to do the work.

It is intentional that you can register more than one string for a provider. This is because one custom provider I'm working on for a third-party database has a provider name of `Foo.Data.Provider`, but the other types are called `BarConnection` and `BarFactory`.

I was also thinking about a more complicated and more powerful solution, but it would require a breaking change (new method on `IProvider`).