### PR TITLE
Make providerName required for constructor overload

### DIFF
--- a/PetaPoco/Database.cs
+++ b/PetaPoco/Database.cs
@@ -81,16 +81,15 @@ namespace PetaPoco
         }
 
         /// <summary>
-        ///     Constructs an instance using a supplied connections string and optionally a provider name. If no provider name is
-        ///     given, the default database provider will be MS SQL Server.
+        ///     Constructs an instance using a supplied connections string and provider name. 
         /// </summary>
         /// <param name="connectionString">The database connection string.</param>
-        /// <param name="providerName">The database provider name, if given.</param>
+        /// <param name="providerName">The database provider name.</param>
         /// <remarks>
         ///     PetaPoco will automatically close and dispose any connections it creates.
         /// </remarks>
         /// <exception cref="ArgumentException">Thrown when <paramref name="connectionString" /> is null or empty.</exception>
-        public Database(string connectionString, string providerName = null)
+        public Database(string connectionString, string providerName)
         {
             if (string.IsNullOrEmpty(connectionString))
                 throw new ArgumentException("Connection string cannot be null or empty", "connectionString");


### PR DESCRIPTION
One of the constructors for `Database` is `public Database(string connectionString, string providerName = null)`

However, if `providerName` is actually omitted and only one string parameter is given, the constructor that winds up being called is `public Database(string connectionStringName)`. In other words, there is no way to call the first overload above without also specifying a provider name. 

So I think the `providerName` parameter should be made mandatory, to avoid any misunderstandings. If this PR gets merged, I'll also update the docs.