### PR TITLE
Convert to multitargeted .NET Standard/Framework project

### DIFF
--- a/PetaPoco.sln
+++ b/PetaPoco.sln
@@ -1,13 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.27428.2015
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PetaPoco", "PetaPoco\PetaPoco.csproj", "{33699753-151D-4100-8F12-9AE1AEB5C5BD}"
-	ProjectSection(ProjectDependencies) = postProject
-		{53F07078-98EA-4494-9829-74245992A7F1} = {53F07078-98EA-4494-9829-74245992A7F1}
-	EndProjectSection
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PetaPoco.Cs.Joiner", "PetaPoco.Cs.Joiner\PetaPoco.Cs.Joiner.csproj", "{53F07078-98EA-4494-9829-74245992A7F1}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Peta Single File", "Peta Single File", "{2DAA4086-AC09-4C47-95DF-21917E529022}"
@@ -31,6 +26,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PetaPoco.Tests.Integration.SingleFile", "PetaPoco.Tests.Integration.SingleFile\PetaPoco.Tests.Integration.SingleFile.csproj", "{9B2D7B13-A47D-497C-9E46-85B78C2D074E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PetaPoco.Tests.Integration.x86", "PetaPoco.Tests.Integration.x86\PetaPoco.Tests.Integration.x86.csproj", "{9AAEF733-6F2A-4297-A0E2-D065212940A3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PetaPoco", "PetaPoco\PetaPoco.csproj", "{F6CC0E46-DEDB-401A-91B2-5CBEDE8F950B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -66,8 +63,15 @@ Global
 		{9AAEF733-6F2A-4297-A0E2-D065212940A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9AAEF733-6F2A-4297-A0E2-D065212940A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9AAEF733-6F2A-4297-A0E2-D065212940A3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F6CC0E46-DEDB-401A-91B2-5CBEDE8F950B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F6CC0E46-DEDB-401A-91B2-5CBEDE8F950B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F6CC0E46-DEDB-401A-91B2-5CBEDE8F950B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F6CC0E46-DEDB-401A-91B2-5CBEDE8F950B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {AC2D57D2-EAB5-4E28-92DC-2E5CB4AEBDF1}
 	EndGlobalSection
 EndGlobal

--- a/PetaPoco/PetaPoco.csproj
+++ b/PetaPoco/PetaPoco.csproj
@@ -1,138 +1,34 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{33699753-151D-4100-8F12-9AE1AEB5C5BD}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>PetaPoco</RootNamespace>
-    <AssemblyName>PetaPoco</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <TargetFrameworkProfile />
-    <FileAlignment>512</FileAlignment>
-    <LangVersion>5</LangVersion>
+    <TargetFrameworks>net40;netstandard2.0</TargetFrameworks>
+    <AssemblyTitle>PetaPoco</AssemblyTitle>
+    <Description>A Tiny ORMish thing for your POCO's.</Description>
+    <Company>Collaborating Platypus</Company>
+    <Product>PetaPoco</Product>
+    <Copyright>Copyright © 2011-2016. Collaborating Platypus</Copyright>
   </PropertyGroup>
-  <PropertyGroup>
-    <StartupObject />
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <DebugSymbols>true</DebugSymbols>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <DebugType>full</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <OutputPath>bin\$(Configuration)\$(TargetFrameworkVersion)\</OutputPath>
-    <CodeAnalysisRuleSet>PetaPoco.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <OutputPath>bin\$(Configuration)\$(TargetFrameworkVersion)\</OutputPath>
-    <CodeAnalysisRuleSet>PetaPoco.ruleset</CodeAnalysisRuleSet>
-    <DocumentationFile>bin\Release\v4.0\PetaPoco.xml</DocumentationFile>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFrameworkVersion)' == 'v4.0'">
-    <DefineConstants>$(DefineConstants);NET40</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFrameworkVersion)' == 'v4.5'">
-    <DefineConstants>$(DefineConstants);NET45</DefineConstants>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.configuration" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.XML" />
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
+    <Reference Include="System.Configuration" />
   </ItemGroup>
+  
+  
+
   <ItemGroup>
-    <Compile Include="Attributes\ColumnAttribute.cs" />
-    <Compile Include="Attributes\ValueConverterAttribute.cs" />
-    <Compile Include="Core\AnsiString.cs" />
-    <Compile Include="Core\ColumnInfo.cs" />
-    <Compile Include="Core\ConventionMapper.cs" />
-    <Compile Include="Core\GridReader.cs" />
-    <Compile Include="Core\IGridReader.cs" />
-    <Compile Include="Core\Inflection\Inflector.cs" />
-    <Compile Include="Core\IProvider.cs" />
-    <Compile Include="Core\ITransaction.cs" />
-    <Compile Include="Core\Mappers.cs" />
-    <Compile Include="Core\MultiPocoFactory.cs" />
-    <Compile Include="Core\DatabaseProvider.cs" />
-    <Compile Include="Core\Inflection\EnglishInflector.cs" />
-    <Compile Include="Core\Inflection\IInflector.cs" />
-    <Compile Include="Core\StandardMapper.cs" />
-    <Compile Include="DatabaseConfiguration.cs" />
-    <Compile Include="DatabaseConfigurationExtensions.cs" />
-    <Compile Include="IBuildConfigurationSettings.cs" />
-    <Compile Include="IDatabaseBuildConfiguration.cs" />
-    <Compile Include="IHideObjectMethods.cs" />
-    <Compile Include="ITransactionAccessor.cs" />
-    <Compile Include="Providers\FirebirdDbDatabaseProvider.cs" />
-    <Compile Include="Providers\MariaDbDatabaseProvider.cs" />
-    <Compile Include="Providers\MsAccessDbDatabaseProvider.cs" />
-    <Compile Include="Providers\SQLiteDatabaseProvider.cs" />
-    <Compile Include="Providers\OracleDatabaseProvider.cs" />
-    <Compile Include="Providers\PostgreSQLDatabaseProvider.cs" />
-    <Compile Include="Providers\SqlServerDatabaseProvider.cs" />
-    <Compile Include="Providers\SqlServerCEDatabaseProviders.cs" />
-    <Compile Include="Providers\MySqlDatabaseProvider.cs" />
-    <Compile Include="IAlterPoco.cs" />
-    <Compile Include="IDatabase.cs" />
-    <Compile Include="IExecute.cs" />
-    <Compile Include="IQuery.cs" />
-    <Compile Include="Utilities\AutoSelectHelper.cs" />
-    <Compile Include="Utilities\IPagingHelper.cs" />
-    <Compile Include="Utilities\PagingHelper.cs" />
-    <Compile Include="Utilities\ParametersHelper.cs" />
-    <Compile Include="Core\ExpandoColumn.cs" />
-    <Compile Include="Core\PocoColumn.cs" />
-    <Compile Include="Core\PocoData.cs" />
-    <Compile Include="Core\IMapper.cs" />
-    <Compile Include="Core\Transaction.cs" />
-    <Compile Include="Core\Sql.cs" />
-    <Compile Include="Core\TableInfo.cs" />
-    <Compile Include="Core\Page.cs" />
-    <Compile Include="Attributes\PrimaryKeyAttribute.cs" />
-    <Compile Include="Attributes\TableNameAttribute.cs" />
-    <Compile Include="Attributes\ResultColumnAttribute.cs" />
-    <Compile Include="Attributes\IgnoreAttribute.cs" />
-    <Compile Include="Attributes\ExplicitColumnsAttribute.cs" />
-    <Compile Include="OracleProvider.cs" />
-    <Compile Include="Database.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Utilities\ArrayKey.cs" />
-    <Compile Include="Utilities\Cache.cs" />
-    <Compile Include="Utilities\EnumMapper.cs" />
-    <Compile Include="Utilities\Singleton.cs" />
-    <Compile Include="Utilities\SQLParts.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="PetaPoco.ruleset" />
-    <None Include="T4 Templates\PetaPoco.Core.ttinclude" />
-    <None Include="T4 Templates\PetaPoco.Generator.ttinclude" />
-    <None Include="T4 Templates\Database.tt">
-      <LastGenOutput>Database.cs</LastGenOutput>
+    <None Update="T4 Templates\Database.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
     </None>
   </ItemGroup>
-  <ItemGroup>
-    <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
+  
+  
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.1" />
+    <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>
-      "$(ProjectDir)..\Tools\PetaPoco.Cs.Joiner.exe" "$(ProjectDir)\"
-      COPY "$(ProjectDir)T4 Templates\*" "$(ProjectDir)..\Output\"
-     </PostBuildEvent>
-  </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+  
+  
+
 </Project>

--- a/PetaPoco/PetaPoco.csproj.user
+++ b/PetaPoco/PetaPoco.csproj.user
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <ProjectView>ShowAllFiles</ProjectView>
-  </PropertyGroup>
-</Project>

--- a/PetaPoco/Properties/AssemblyInfo.cs
+++ b/PetaPoco/Properties/AssemblyInfo.cs
@@ -8,19 +8,6 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
-[assembly: AssemblyTitle("PetaPoco")]
-[assembly: AssemblyDescription("A Tiny ORMish thing for your POCO's.")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Collaborating Platypus")]
-[assembly: AssemblyProduct("PetaPoco")]
-[assembly: AssemblyCopyright("Copyright © 2011-2016. Collaborating Platypus")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
@@ -42,7 +29,7 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("5.0.1.*")]
+//[assembly: AssemblyVersion("5.0.1.*")]
 [assembly: InternalsVisibleTo("PetaPoco.Tests")]
 [assembly: InternalsVisibleTo("PetaPoco.Tests.Unit")]
 [assembly: InternalsVisibleTo("PetaPoco.Tests.Integration")]

--- a/PetaPoco/Providers/MsAccessDbDatabaseProvider.cs
+++ b/PetaPoco/Providers/MsAccessDbDatabaseProvider.cs
@@ -16,7 +16,7 @@ namespace PetaPoco.Providers
     {
         public override DbProviderFactory GetFactory()
         {
-            return DbProviderFactories.GetFactory("System.Data.OleDb");
+            return GetFactory("System.Data.OleDb.OleDbFactory, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
         }
 
         public override object ExecuteInsert(Database database, IDbCommand cmd, string primaryKeyName)


### PR DESCRIPTION
I'd love to get this library .NET Standard compatible. Maybe we can use this PR to work on it.

 It looks like the only needed code change is `GetFactory()` in the MSAccess provider. It also means upgrading to VS 2017. I'm happy to help with multi-targeting the unit tests, but I'm not sure I have the right setup for the integration tests.