### PR TITLE
Include result column in auto select

### DIFF
--- a/PetaPoco.Tests.Unit/Core/PocoDataTests.cs
+++ b/PetaPoco.Tests.Unit/Core/PocoDataTests.cs
@@ -29,5 +29,33 @@ namespace PetaPoco.Tests.Unit.Core
             {
             }
         }
+
+        public class PocoWithResultColumn
+        {
+            public string RegularProperty { get; set; }
+            [ResultColumn]
+            public string ResultProperty { get; set; }
+        }
+
+        public class PocoWithIncludedResultColumn
+        {
+            public string RegularProperty { get; set; }
+            [ResultColumn(IncludeInAutoSelect.Yes)]
+            public string ResultProperty { get; set; }
+        }
+
+        [Fact]
+        public void PD_ResultColumn_NotInAutoSelect()
+        {
+            var pd = PocoData.ForType(typeof(PocoWithResultColumn), new ConventionMapper());
+            pd.QueryColumns.ShouldBe(new[] { "RegularProperty" });
+        }
+
+        [Fact]
+        public void PD_IncludedResultColumn_InAutoSelect()
+        {
+            var pd = PocoData.ForType(typeof(PocoWithIncludedResultColumn), new ConventionMapper());
+            pd.QueryColumns.ShouldBe(new[] { "RegularProperty", "ResultProperty" });
+        }
     }
 }

--- a/PetaPoco/Attributes/ResultColumnAttribute.cs
+++ b/PetaPoco/Attributes/ResultColumnAttribute.cs
@@ -8,6 +8,8 @@ using System;
 
 namespace PetaPoco
 {
+    public enum IncludeInAutoSelect { No, Yes }
+
     /// <summary>
     ///     Represents an attribute which can decorate a poco property as a result only column. A result only column is a
     ///     column that is only populated in queries and is not used for updates or inserts operations.
@@ -15,13 +17,26 @@ namespace PetaPoco
     [AttributeUsage(AttributeTargets.Property)]
     public class ResultColumnAttribute : ColumnAttribute
     {
+        public IncludeInAutoSelect IncludeInAutoSelect { get; set; }
+
         public ResultColumnAttribute()
         {
         }
 
-        public ResultColumnAttribute(string name)
+        public ResultColumnAttribute(string name) 
+            : this(name, IncludeInAutoSelect.No)
+        {
+        }
+
+        public ResultColumnAttribute(IncludeInAutoSelect includeInAutoSelect)
+            : this(null, includeInAutoSelect)
+        {
+        }
+
+        public ResultColumnAttribute(string name, IncludeInAutoSelect includeInAutoSelect)
             : base(name)
         {
+            IncludeInAutoSelect = includeInAutoSelect;
         }
     }
 }

--- a/PetaPoco/Core/ColumnInfo.cs
+++ b/PetaPoco/Core/ColumnInfo.cs
@@ -9,11 +9,11 @@ using System.Reflection;
 namespace PetaPoco
 {
     /// <summary>
-    ///     Hold information about a column in the database.
+    ///     Holds information about a column in the database.
     /// </summary>
     /// <remarks>
-    ///     Typically ColumnInfo is automatically populated from the attributes on a POCO object and it's properties. It can
-    ///     however also be returned from the IMapper interface to provide your owning bindings between the DB and your POCOs.
+    ///     Typically ColumnInfo is automatically populated from the attributes on a POCO object and its properties. It can
+    ///     however also be returned from the IMapper interface to provide your own bindings between the DB and your POCOs.
     /// </remarks>
     public class ColumnInfo
     {
@@ -27,6 +27,11 @@ namespace PetaPoco
         ///     operations.
         /// </summary>
         public bool ResultColumn { get; set; }
+
+        /// <summary>
+        /// True if this is a result column but should be included in auto select queries.
+        /// </summary>
+        public bool AutoSelectedResultColumn { get; set; }
 
         /// <summary>
         ///     True if time and date values returned through this column should be forced to UTC DateTimeKind. (no conversion is

--- a/PetaPoco/Core/ConventionMapper.cs
+++ b/PetaPoco/Core/ConventionMapper.cs
@@ -145,6 +145,7 @@ namespace PetaPoco
                     ci.ColumnName = column.Name ?? InflectColumnName(Inflector.Instance, pi.Name);
                     ci.ForceToUtc = column.ForceToUtc;
                     ci.ResultColumn = (column as ResultColumnAttribute) != null;
+                    ci.AutoSelectedResultColumn = (column as ResultColumnAttribute)?.IncludeInAutoSelect == IncludeInAutoSelect.Yes;
                     ci.InsertTemplate = column.InsertTemplate;
                     ci.UpdateTemplate = column.UpdateTemplate;
                 }

--- a/PetaPoco/Core/PocoColumn.cs
+++ b/PetaPoco/Core/PocoColumn.cs
@@ -15,6 +15,7 @@ namespace PetaPoco.Core
         public bool ForceToUtc;
         public PropertyInfo PropertyInfo;
         public bool ResultColumn;
+        public bool AutoSelectedResultColumn;
         public string InsertTemplate { get; set; }
         public string UpdateTemplate { get; set; }
 

--- a/PetaPoco/Core/PocoData.cs
+++ b/PetaPoco/Core/PocoData.cs
@@ -64,6 +64,7 @@ namespace PetaPoco.Core
                 pc.PropertyInfo = pi;
                 pc.ColumnName = ci.ColumnName;
                 pc.ResultColumn = ci.ResultColumn;
+                pc.AutoSelectedResultColumn = ci.AutoSelectedResultColumn;
                 pc.ForceToUtc = ci.ForceToUtc;
                 pc.InsertTemplate = ci.InsertTemplate;
                 pc.UpdateTemplate = ci.UpdateTemplate;
@@ -73,7 +74,9 @@ namespace PetaPoco.Core
             }
 
             // Build column list for automatic select
-            QueryColumns = (from c in Columns where !c.Value.ResultColumn select c.Key).ToArray();
+            QueryColumns = (from c in Columns
+                            where !c.Value.ResultColumn || c.Value.AutoSelectedResultColumn
+                            select c.Key).ToArray();
         }
 
         public static PocoData ForObject(object obj, string primaryKeyName, IMapper defaultMapper)


### PR DESCRIPTION
I decided to implement this with an enum instead of a bool param in the constructor -- `ResultColumn(false)` just looked too much like it was saying that the field is _not_ a result column.

In `ColumnInfo` and `PocoColumn`, I called the field `AutoSelectedResultColumn`, because keeping the name as `IncludeInAutoSelect` made its purpose sound too broad.

