### PR TITLE
Event handlers

### DIFF
--- a/PetaPoco.Tests.Unit/DatabaseConfigurationTests.cs
+++ b/PetaPoco.Tests.Unit/DatabaseConfigurationTests.cs
@@ -82,7 +82,7 @@ namespace PetaPoco.Tests.Unit
         }
 
         [Fact]
-        public void UsingCreate_GivenMinimalConfiguration_ShouldNotAffectPetaPoocDefaults()
+        public void UsingCreate_GivenMinimalConfiguration_ShouldNotAffectPetaPocoDefaults()
         {
             var db = config
                 .UsingConnectionString("cs")
@@ -268,6 +268,119 @@ namespace PetaPoco.Tests.Unit
                 .Create();
 
             db.IsolationLevel.ShouldBeNull();
+        }
+
+        [Fact]
+        public void UsingCommandExecuting_AfterCreate_InstanceShouldHaveDelegate()
+        {
+            bool eventFired = false;
+            EventHandler<DbCommandEventArgs> handler = (sender, args) => eventFired = true;
+
+            var db = config
+                .UsingConnectionString("cs")
+                .UsingProvider<SqlServerDatabaseProvider>()
+                .UsingCommandExecuting(handler)
+                .Create();
+
+            // Can't inspect the event directly, so we have to get it to fire
+            (db as Database).OnExecutingCommand(null);
+            eventFired.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void UsingCommandExecuted_AfterCreate_InstanceShouldHaveDelegate()
+        {
+            bool eventFired = false;
+            EventHandler<DbCommandEventArgs> handler = (sender, args) => eventFired = true;
+            
+            var db = config
+                .UsingConnectionString("cs")
+                .UsingProvider<SqlServerDatabaseProvider>()
+                .UsingCommandExecuted(handler)
+                .Create();
+
+            (db as Database).OnExecutedCommand(null);
+            eventFired.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void UsingConnectionClosing_AfterCreate_InstanceShouldHaveDelegate()
+        {
+            bool eventFired = false;
+            EventHandler<DbConnectionEventArgs> handler = (sender, args) => eventFired = true;
+
+            var db = config
+                .UsingConnectionString("cs")
+                .UsingProvider<SqlServerDatabaseProvider>()
+                .UsingConnectionClosing(handler)
+                .Create();
+
+            (db as Database).OnConnectionClosing(null);
+            eventFired.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void UsingConnectionOpened_AfterCreate_InstanceShouldHaveDelegate()
+        {
+            bool eventFired = false;
+            EventHandler<DbConnectionEventArgs> handler = (sender, args) => eventFired = true;
+
+            var db = config
+                .UsingConnectionString("cs")
+                .UsingProvider<SqlServerDatabaseProvider>()
+                .UsingConnectionOpened(handler)
+                .Create();
+
+            (db as Database).OnConnectionOpened(null);
+            eventFired.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void UsingTransactionStarted_AfterCreate_InstanceShouldHaveDelegate()
+        {
+            bool eventFired = false;
+            EventHandler<DbTransactionEventArgs> handler = (sender, args) => eventFired = true;
+
+            var db = config
+                .UsingConnectionString("cs")
+                .UsingProvider<SqlServerDatabaseProvider>()
+                .UsingTransactionStarted(handler)
+                .Create();
+
+            (db as Database).OnBeginTransaction();
+            eventFired.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void UsingTransactionEnding_AfterCreate_InstanceShouldHaveDelegate()
+        {
+            bool eventFired = false;
+            EventHandler<DbTransactionEventArgs> handler = (sender, args) => eventFired = true;
+
+            var db = config
+                .UsingConnectionString("cs")
+                .UsingProvider<SqlServerDatabaseProvider>()
+                .UsingTransactionEnding(handler)
+                .Create();
+
+            (db as Database).OnEndTransaction();
+            eventFired.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void UsingExceptionThrown_AfterCreate_InstanceShouldHaveDelegate()
+        {
+            bool eventFired = false;
+            EventHandler<ExceptionEventArgs> handler = (sender, args) => eventFired = true;
+
+            var db = config
+                .UsingConnectionString("cs")
+                .UsingProvider<SqlServerDatabaseProvider>()
+                .UsingExceptionThrown(handler)
+                .Create();
+
+            (db as Database).OnException(new Exception());
+            eventFired.ShouldBeTrue();
         }
     }
 }

--- a/PetaPoco/Database.cs
+++ b/PetaPoco/Database.cs
@@ -369,6 +369,7 @@ namespace PetaPoco
         /// </summary>
         public virtual void OnBeginTransaction()
         {
+            TransactionStarted?.Invoke(this, new DbTransactionEventArgs(_transaction));
         }
 
         /// <summary>
@@ -376,6 +377,7 @@ namespace PetaPoco
         /// </summary>
         public virtual void OnEndTransaction()
         {
+            TransactionEnding?.Invoke(this, new DbTransactionEventArgs(_transaction));
         }
 
         /// <summary>
@@ -582,7 +584,10 @@ namespace PetaPoco
         {
             System.Diagnostics.Debug.WriteLine(x.ToString());
             System.Diagnostics.Debug.WriteLine(LastCommand);
-            return true;
+
+            var args = new ExceptionEventArgs(x);
+            ExceptionThrown?.Invoke(this, new ExceptionEventArgs(x));
+            return args.Raise;
         }
 
         /// <summary>
@@ -596,7 +601,9 @@ namespace PetaPoco
         /// </remarks>
         public virtual IDbConnection OnConnectionOpened(IDbConnection conn)
         {
-            return conn;
+            var args = new DbConnectionEventArgs(conn);
+            ConnectionOpened?.Invoke(this, args);
+            return args.Connection;
         }
 
         /// <summary>
@@ -605,6 +612,7 @@ namespace PetaPoco
         /// <param name="conn">The soon to be closed IDBConnection</param>
         public virtual void OnConnectionClosing(IDbConnection conn)
         {
+            ConnectionClosing?.Invoke(this, new DbConnectionEventArgs(conn));
         }
 
         /// <summary>
@@ -617,6 +625,7 @@ namespace PetaPoco
         /// </remarks>
         public virtual void OnExecutingCommand(IDbCommand cmd)
         {
+            CommandExecuting?.Invoke(this, new DbCommandEventArgs(cmd));
         }
 
         /// <summary>
@@ -625,6 +634,7 @@ namespace PetaPoco
         /// <param name="cmd">The IDbCommand that finished executing</param>
         public virtual void OnExecutedCommand(IDbCommand cmd)
         {
+            CommandExecuted?.Invoke(this, new DbCommandEventArgs(cmd));
         }
 
         #endregion
@@ -2710,6 +2720,37 @@ namespace PetaPoco
         private DbProviderFactory _factory;
         private IsolationLevel? _isolationLevel;
 
+        #endregion
+
+        #region Events
+        /// <summary>
+        /// Occurs when a new transaction has started.
+        /// </summary>
+        public event EventHandler<DbTransactionEventArgs> TransactionStarted;
+        /// <summary>
+        /// Occurs when a transaction is about to be rolled back or committed.
+        /// </summary>
+        public event EventHandler<DbTransactionEventArgs> TransactionEnding;
+        /// <summary>
+        /// Occurs when a database command is about to be executed.
+        /// </summary>
+        public event EventHandler<DbCommandEventArgs> CommandExecuting;
+        /// <summary>
+        /// Occurs when a database command has been executed.
+        /// </summary>
+        public event EventHandler<DbCommandEventArgs> CommandExecuted;
+        /// <summary>
+        /// Occurs when a database connection is about to be closed.
+        /// </summary>
+        public event EventHandler<DbConnectionEventArgs> ConnectionClosing;
+        /// <summary>
+        /// Occurs when a database connection has been opened.
+        /// </summary>
+        public event EventHandler<DbConnectionEventArgs> ConnectionOpened;
+        /// <summary>
+        /// Occurs when a database exception has been thrown.
+        /// </summary>
+        public event EventHandler<ExceptionEventArgs> ExceptionThrown;
         #endregion
     }
 }

--- a/PetaPoco/Database.cs
+++ b/PetaPoco/Database.cs
@@ -251,6 +251,14 @@ namespace PetaPoco
             settings.TryGetSetting<bool>(DatabaseConfigurationExtensions.EnableAutoSelect, v => EnableAutoSelect = v);
             settings.TryGetSetting<int>(DatabaseConfigurationExtensions.CommandTimeout, v => CommandTimeout = v);
             settings.TryGetSetting<IsolationLevel>(DatabaseConfigurationExtensions.IsolationLevel, v => IsolationLevel = v);
+
+            settings.TryGetSetting<EventHandler<DbConnectionEventArgs>>(DatabaseConfigurationExtensions.ConnectionOpened, v => ConnectionOpened += v);
+            settings.TryGetSetting<EventHandler<DbConnectionEventArgs>>(DatabaseConfigurationExtensions.ConnectionClosing, v => ConnectionClosing += v);
+            settings.TryGetSetting<EventHandler<DbTransactionEventArgs>>(DatabaseConfigurationExtensions.TransactionStarted, v => TransactionStarted += v);
+            settings.TryGetSetting<EventHandler<DbTransactionEventArgs>>(DatabaseConfigurationExtensions.TransactionEnding, v => TransactionEnding += v);
+            settings.TryGetSetting<EventHandler<DbCommandEventArgs>>(DatabaseConfigurationExtensions.CommandExecuting, v => CommandExecuting += v);
+            settings.TryGetSetting<EventHandler<DbCommandEventArgs>>(DatabaseConfigurationExtensions.CommandExecuted, v => CommandExecuted += v);
+            settings.TryGetSetting<EventHandler<ExceptionEventArgs>>(DatabaseConfigurationExtensions.ExceptionThrown, v => ExceptionThrown += v);
         }
 
         /// <summary>

--- a/PetaPoco/DatabaseConfigurationExtensions.cs
+++ b/PetaPoco/DatabaseConfigurationExtensions.cs
@@ -16,13 +16,9 @@ namespace PetaPoco
     public static class DatabaseConfigurationExtensions
     {
         internal const string CommandTimeout = "CommandTimeout";
-
         internal const string EnableAutoSelect = "EnableAutoSelect";
-
         internal const string EnableNamedParams = "EnableNamedParams";
-
         internal const string Provider = "Provider";
-
         internal const string ConnectionString = "ConnectionString";
 
 #if !NETSTANDARD
@@ -32,8 +28,16 @@ namespace PetaPoco
 #endif
 
         internal const string DefaultMapper = "DefaultMapper";
-
         internal const string IsolationLevel = "IsolationLevel";
+        internal const string TransactionStarted = "TransactionStarted";
+        internal const string TransactionEnding = "TransactionEnding";
+        internal const string CommandExecuting = "CommandExecuting";
+        internal const string CommandExecuted = "CommandExecuted";
+        internal const string ConnectionOpened = "ConnectionOpened";
+        internal const string ConnectionClosing = "ConnectionClosing";
+        internal const string ExceptionThrown = "ExceptionThrown";
+
+
 
         private static void SetSetting(this IDatabaseBuildConfiguration source, string key, object value)
         {
@@ -296,6 +300,50 @@ namespace PetaPoco
             source.SetSetting(IsolationLevel, isolationLevel);
             return source;
         }
+
+        public static IDatabaseBuildConfiguration UsingTransactionStarted(this IDatabaseBuildConfiguration source, EventHandler<DbTransactionEventArgs> handler)
+        {
+            source.SetSetting(TransactionStarted, handler);
+            return source;
+        }
+
+        public static IDatabaseBuildConfiguration UsingTransactionEnding(this IDatabaseBuildConfiguration source, EventHandler<DbTransactionEventArgs> handler)
+        {
+            source.SetSetting(TransactionEnding, handler);
+            return source;
+        }
+
+        public static IDatabaseBuildConfiguration UsingCommandExecuting(this IDatabaseBuildConfiguration source, EventHandler<DbCommandEventArgs> handler)
+        {
+            source.SetSetting(CommandExecuting, handler);
+            return source;
+        }
+
+        public static IDatabaseBuildConfiguration UsingCommandExecuted(this IDatabaseBuildConfiguration source, EventHandler<DbCommandEventArgs> handler)
+        {
+            source.SetSetting(CommandExecuted, handler);
+            return source;
+        }
+
+        public static IDatabaseBuildConfiguration UsingConnectionOpened(this IDatabaseBuildConfiguration source, EventHandler<DbConnectionEventArgs> handler)
+        {
+            source.SetSetting(ConnectionOpened, handler);
+            return source;
+        }
+
+        public static IDatabaseBuildConfiguration UsingConnectionClosing(this IDatabaseBuildConfiguration source, EventHandler<DbConnectionEventArgs> handler)
+        {
+            source.SetSetting(ConnectionClosing, handler);
+            return source;
+        }
+
+        public static IDatabaseBuildConfiguration UsingExceptionThrown(this IDatabaseBuildConfiguration source, EventHandler<ExceptionEventArgs> handler)
+        {
+            source.SetSetting(ExceptionThrown, handler);
+            return source;
+        }
+
+
 
         /// <summary>
         ///     Creates an instance of PetaPooc using the specified <paramref name="source" />.

--- a/PetaPoco/EventArgs.cs
+++ b/PetaPoco/EventArgs.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PetaPoco
+{
+    public class DbTransactionEventArgs: EventArgs
+    {
+        public IDbTransaction Transaction { get; private set; }
+
+        public DbTransactionEventArgs(IDbTransaction transaction)
+        {
+            Transaction = transaction;
+        }
+    }
+
+    public class DbCommandEventArgs: EventArgs
+    {
+        public IDbCommand Command { get; private set; }
+
+        public DbCommandEventArgs(IDbCommand cmd)
+        {
+            Command = cmd;
+        }
+    }
+
+    public class DbConnectionEventArgs : EventArgs
+    {
+        public IDbConnection Connection { get; set; }
+
+        public DbConnectionEventArgs(IDbConnection connection)
+        {
+            Connection = connection;
+        }
+    }
+
+    public class ExceptionEventArgs: EventArgs
+    {
+        public bool Raise { get; set; } = true;
+        public Exception Exception { get; private set; }
+
+        public ExceptionEventArgs(Exception ex)
+        {
+            Exception = ex;
+        }
+    }
+}

--- a/PetaPoco/IDatabase.cs
+++ b/PetaPoco/IDatabase.cs
@@ -155,5 +155,34 @@ namespace PetaPoco
         ///     Marks the current transaction scope as complete.
         /// </summary>
         void CompleteTransaction();
+
+        /// <summary>
+        /// Occurs when a new transaction has started.
+        /// </summary>
+        event EventHandler<DbTransactionEventArgs> TransactionStarted;
+        /// <summary>
+        /// Occurs when a transaction is about to be rolled back or committed.
+        /// </summary>
+        event EventHandler<DbTransactionEventArgs> TransactionEnding;
+        /// <summary>
+        /// Occurs when a database command is about to be executed.
+        /// </summary>
+        event EventHandler<DbCommandEventArgs> CommandExecuting;
+        /// <summary>
+        /// Occurs when a database command has been executed.
+        /// </summary>
+        event EventHandler<DbCommandEventArgs> CommandExecuted;
+        /// <summary>
+        /// Occurs when a database connection is about to be closed.
+        /// </summary>
+        event EventHandler<DbConnectionEventArgs> ConnectionClosing;
+        /// <summary>
+        /// Occurs when a database connection has been opened.
+        /// </summary>
+        event EventHandler<DbConnectionEventArgs> ConnectionOpened;
+        /// <summary>
+        /// Occurs when a database exception has been thrown.
+        /// </summary>
+        event EventHandler<ExceptionEventArgs> ExceptionThrown;
     }
 }


### PR DESCRIPTION
Closes #489 

Note that the events are not named exactly the same as the methods from which they are called -- for example, `OnExecutingCommand()` calls event `CommandExecuting`. For ease of discoverability, I opted to use a naming pattern that's consistent with other .NET classes.