### PR TITLE
Remove AddParameter()

### DIFF
--- a/PetaPoco.Tests.Unit/Core/SqlTests.cs
+++ b/PetaPoco.Tests.Unit/Core/SqlTests.cs
@@ -5,7 +5,6 @@
 // <date>2018/07/02</date>
 
 using System;
-using System.Data.SqlClient;
 using PetaPoco.Tests.Unit.Models;
 using Shouldly;
 using Xunit;
@@ -366,65 +365,6 @@ namespace PetaPoco.Tests.Unit.Core
             sqlCapture1.Replace("\n", " ").ShouldBe("SELECT field");
             sqlCapture2.Replace("\n", " ").ShouldBe("SELECT field FROM myTable");
             sqlCapture3.Replace("\n", " ").ShouldBe("SELECT field FROM myTable WHERE (id = @0)");
-        }
-
-        [Fact]
-        public void AddParameter_GivenParam_ShouldBeValid()
-        {
-            var param = new SqlParameter();
-            _sql = Sql.Builder.AddParameter(param);
-
-            _sql.SQL.ShouldBeEmpty();
-            _sql.Arguments.Length.ShouldBe(1);
-            _sql.Arguments[0].ShouldBe(param);
-        }
-
-        [Fact]
-        public void AddParameter_GivenSimpleSqlAndParam_ShouldBeValid()
-        {
-            var param = new SqlParameter();
-            _sql = Sql.Builder
-                .Select("*")
-                .From("mytable")
-                .AddParameter(param);
-
-            _sql.SQL.ShouldBe("SELECT *\nFROM mytable");
-            _sql.Arguments.Length.ShouldBe(1);
-            _sql.Arguments[0].ShouldBe(param);
-        }
-
-        [Fact]
-        public void AddParameter_GivenComplexSqlAndParam_ShouldBeValid()
-        {
-            var param = new SqlParameter();
-            _sql = Sql.Builder
-                .Select("*")
-                .From("mytable")
-                .Where("myfield=@0", 4)
-                .AddParameter(param);
-
-            _sql.SQL.ShouldBe("SELECT *\nFROM mytable\nWHERE (myfield=@0)");
-            _sql.Arguments.Length.ShouldBe(2);
-            _sql.Arguments[0].ShouldBe(4);
-            _sql.Arguments[1].ShouldBe(param);
-        }
-
-        [Fact]
-        public void AddParameter_CombineTwoSqls_ShouldBeValid()
-        {
-            var param = new SqlParameter();
-            var paramSql = Sql.Builder.AddParameter(param);
-
-            _sql = Sql.Builder
-                .Select("*")
-                .From("mytable")
-                .Where("myfield=@0", 4)
-                .Append(paramSql);
-
-            _sql.SQL.ShouldBe("SELECT *\nFROM mytable\nWHERE (myfield=@0)");
-            _sql.Arguments.Length.ShouldBe(2);
-            _sql.Arguments[0].ShouldBe(4);
-            _sql.Arguments[1].ShouldBe(param);
         }
     }
 }

--- a/PetaPoco/Core/Sql.cs
+++ b/PetaPoco/Core/Sql.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Linq;
 using System.Text;
 using PetaPoco.Internal;
@@ -145,18 +144,12 @@ namespace PetaPoco
 
                 sb.Append(sql);
             }
-            else
-            {
-                if (_args != null)
-                    args.AddRange(_args.OfType<IDbDataParameter>());
-            }
 
             // Now do rhs
             if (_rhs != null)
                 _rhs.Build(sb, args, this);
         }
 
-        
         /// <summary>
         ///     Appends an SQL SET clause to this SQL builder
         /// </summary>
@@ -242,16 +235,6 @@ namespace PetaPoco
         public SqlJoinClause LeftJoin(string table)
         {
             return Join("LEFT JOIN ", table);
-        }
-
-        /// <summary>
-        ///     Appends an IDbDataParameter to this SQL builder
-        /// </summary>
-        /// <param name="param">The parameter to add</param>
-        /// <returns>A reference to this builder, allowing for fluent style concatenation</returns>
-        public Sql AddParameter(IDbDataParameter param)
-        {
-            return Append(new Sql(null, param));
         }
 
         /// <summary>


### PR DESCRIPTION
Long story short, I think this functionality should be removed.

I didn't think through all of the implications; I got the parameter onto the `Sql` object but didn't pay attention to what would happen in `CreateCommand()`, `ProcessQueryParams()` and `AddParam()`. So currently the scenario envisioned in #488 only works if `EnableNamedParameters == false` and the placeholder in `Join()` is `@@0`. Any other combination fails, for one reason or another. I consider these conditions too narrow to count as a success.

There could be more work done to get all parts of this to work, but it's a longer and more invasive procedure, and personally I'm not sure it's worth it. There are a few viable workarounds for the original reported issue, and I think it should just be left at that.