### PR TITLE
Add generic db constructor, and add optional mapper to all

### DIFF
--- a/PetaPoco.Tests.Unit/DatabaseTests.cs
+++ b/PetaPoco.Tests.Unit/DatabaseTests.cs
@@ -11,7 +11,9 @@ using System.Data.SqlClient;
 using System.Dynamic;
 using Moq;
 using PetaPoco.Core;
+using PetaPoco.Providers;
 using PetaPoco.Tests.Unit.Models;
+using PetaPoco.Utilities;
 using Shouldly;
 using Xunit;
 
@@ -95,6 +97,7 @@ namespace PetaPoco.Tests.Unit
                     throw;
                 }
             });
+            Should.Throw<ArgumentException>(() => new Database<SqlServerDatabaseProvider>(null));
         }
 
         [Fact]
@@ -252,6 +255,6 @@ namespace PetaPoco.Tests.Unit
 
                 return null;
             }
-        }
+        }        
     }
 }

--- a/PetaPoco/Database.cs
+++ b/PetaPoco/Database.cs
@@ -72,8 +72,9 @@ namespace PetaPoco
         /// <summary>
         ///     Constructs an instance using the first connection string found in the app/web configuration file.
         /// </summary>
+        /// <param name="defaultMapper">The default mapper to use when no specific mapper has been registered.</param>
         /// <exception cref="InvalidOperationException">Thrown when no connection strings can registered.</exception>
-        public Database()
+        public Database(IMapper defaultMapper = null)
         {
             if (ConfigurationManager.ConnectionStrings.Count == 0)
                 throw new InvalidOperationException("One or more connection strings must be registered to use the no paramater constructor");
@@ -81,7 +82,7 @@ namespace PetaPoco
             var entry = ConfigurationManager.ConnectionStrings[0];
             _connectionString = entry.ConnectionString;
             var providerName = !string.IsNullOrEmpty(entry.ProviderName) ? entry.ProviderName : "System.Data.SqlClient";
-            Initialise(DatabaseProvider.Resolve(providerName, false, _connectionString), null);
+            Initialise(DatabaseProvider.Resolve(providerName, false, _connectionString), defaultMapper);
         }
 
         /// <summary>
@@ -89,9 +90,10 @@ namespace PetaPoco
         ///     read from app/web.config.
         /// </summary>
         /// <param name="connectionStringName">The name of the connection.</param>
+        /// <param name="defaultMapper">The default mapper to use when no specific mapper has been registered.</param>
         /// <exception cref="ArgumentException">Thrown when <paramref name="connectionStringName" /> is null or empty.</exception>
         /// <exception cref="InvalidOperationException">Thrown when a connection string cannot be found.</exception>
-        public Database(string connectionStringName)
+        public Database(string connectionStringName, IMapper defaultMapper = null)
         {
             if (string.IsNullOrEmpty(connectionStringName))
                 throw new ArgumentException("Connection string name must not be null or empty", nameof(connectionStringName));
@@ -103,7 +105,7 @@ namespace PetaPoco
 
             _connectionString = entry.ConnectionString;
             var providerName = !string.IsNullOrEmpty(entry.ProviderName) ? entry.ProviderName : "System.Data.SqlClient";
-            Initialise(DatabaseProvider.Resolve(providerName, false, _connectionString), null);
+            Initialise(DatabaseProvider.Resolve(providerName, false, _connectionString), defaultMapper);
         }
 #endif
 
@@ -129,21 +131,22 @@ namespace PetaPoco
         }
 
         /// <summary>
-        ///     Constructs an instance using a supplied connections string and provider name.
+        ///     Constructs an instance using a supplied connection string and provider name.
         /// </summary>
         /// <param name="connectionString">The database connection string.</param>
         /// <param name="providerName">The database provider name.</param>
+        /// <param name="defaultMapper">The default mapper to use when no specific mapper has been registered.</param>
         /// <remarks>
         ///     PetaPoco will automatically close and dispose any connections it creates.
         /// </remarks>
         /// <exception cref="ArgumentException">Thrown when <paramref name="connectionString" /> is null or empty.</exception>
-        public Database(string connectionString, string providerName)
+        public Database(string connectionString, string providerName, IMapper defaultMapper = null)
         {
             if (string.IsNullOrEmpty(connectionString))
                 throw new ArgumentException("Connection string cannot be null or empty", nameof(connectionString));
 
             _connectionString = connectionString;
-            Initialise(DatabaseProvider.Resolve(providerName, true, _connectionString), null);
+            Initialise(DatabaseProvider.Resolve(providerName, true, _connectionString), defaultMapper);
         }
 
         /// <summary>
@@ -151,9 +154,10 @@ namespace PetaPoco
         /// </summary>
         /// <param name="connectionString">The database connection string.</param>
         /// <param name="factory">The DbProviderFactory to use for instantiating IDbConnection's.</param>
+        /// <param name="defaultMapper">The default mapper to use when no specific mapper has been registered.</param>
         /// <exception cref="ArgumentException">Thrown when <paramref name="connectionString" /> is null or empty.</exception>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="factory" /> is null.</exception>
-        public Database(string connectionString, DbProviderFactory factory)
+        public Database(string connectionString, DbProviderFactory factory, IMapper defaultMapper = null)
         {
             if (string.IsNullOrEmpty(connectionString))
                 throw new ArgumentException("Connection string must not be null or empty", nameof(connectionString));
@@ -162,7 +166,7 @@ namespace PetaPoco
                 throw new ArgumentNullException(nameof(factory));
 
             _connectionString = connectionString;
-            Initialise(DatabaseProvider.Resolve(DatabaseProvider.Unwrap(factory).GetType(), false, _connectionString), null);
+            Initialise(DatabaseProvider.Resolve(DatabaseProvider.Unwrap(factory).GetType(), false, _connectionString), defaultMapper);
         }
 
         /// <summary>
@@ -2860,5 +2864,19 @@ namespace PetaPoco
         /// </summary>
         public event EventHandler<ExceptionEventArgs> ExceptionThrown;
         #endregion
+    }
+
+    public class Database<TDatabaseProvider> : Database where TDatabaseProvider : IProvider
+    {
+        /// <summary>
+        /// Constructs an instance using a supplied connection string and provider type.
+        /// </summary>
+        /// <param name="connectionString">The database connection string.</param>
+        /// <param name="defaultMapper">The default mapper to use when no specific mapper has been registered.</param>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="connectionString" /> is null or empty.</exception>
+        public Database(string connectionString, IMapper defaultMapper = null)
+            : base(connectionString, typeof(TDatabaseProvider).Name, defaultMapper)
+        {
+        }
     }
 }


### PR DESCRIPTION
When I've been writing little tests for things in LinqPad, I've been using the `Database` constructor that takes a connection string and a provider name, and I've been a little frustrated that I can't always remember the exact name/spelling of a provider. I know that I could use `nameof(SqlServerDatabaseProvider)` to get help from Intellisense, but I thought it would be simpler and more idiomatic if I could just do `new Database<SqlServerDatabaseProvider>(connString)`.

While I was in there, I made sure that all `Database` constructors have the optional `IMapper` parameter, because I couldn't see why some had it and some didn't.