### PR TITLE
Fix for provider initialization sequence in fluent constructor

### DIFF
--- a/PetaPoco.Tests.Unit/DatabaseConfigurationTests.cs
+++ b/PetaPoco.Tests.Unit/DatabaseConfigurationTests.cs
@@ -437,5 +437,24 @@ namespace PetaPoco.Tests.Unit
             db.ConnectionString.ShouldBe(connString);
             db.Provider.ShouldBeOfType<FakeProvider>();
         }
+
+        [Fact]
+        public void UsingConnectionWithProviderName_AfterCreate_InstanceShouldBeValid()
+        {
+            DatabaseProvider.RegisterCustomProvider<FakeProvider>("fake");
+            try
+            {
+                var connString = "Data Source = foo";
+                var connection = new SqlConnection(connString);
+                var db = new Database(config.UsingConnection(connection).UsingProviderName("FakeProvider"));
+
+                db.ConnectionString.ShouldBe(connString);
+                db.Provider.ShouldBeOfType<FakeProvider>();
+            }
+            finally
+            {
+                DatabaseProvider.ClearCustomProviders();
+            }
+        }
     }
 }

--- a/PetaPoco.Tests.Unit/DatabaseTests.cs
+++ b/PetaPoco.Tests.Unit/DatabaseTests.cs
@@ -94,7 +94,7 @@ namespace PetaPoco.Tests.Unit
                 }
                 catch (Exception e)
                 {
-                    e.Message.ShouldContain("Either a provider name or provider must be registered");
+                    e.Message.ShouldContain("Unable to locate a provider");
                     throw;
                 }
             });


### PR DESCRIPTION
There was something missing with #499 -- if you pass in a connection, you could also pass in a provider type, to override what the connection wants to use, but you couldn't pass in a provider name. This PR fixes that and refactors the initialization code a little to be cleaner and more uniform.