### PR TITLE
Make ConventionMapper methods virtual

### DIFF
--- a/PetaPoco/Core/ConventionMapper.cs
+++ b/PetaPoco/Core/ConventionMapper.cs
@@ -183,7 +183,7 @@ namespace PetaPoco
         ///     This method must return a valid TableInfo.
         ///     To create a TableInfo from a POCO's attributes, use TableInfo.FromPoco
         /// </remarks>
-        public TableInfo GetTableInfo(Type pocoType)
+        public virtual TableInfo GetTableInfo(Type pocoType)
         {
             var ti = new TableInfo();
             return MapTable(ti, pocoType) ? ti : null;
@@ -197,7 +197,7 @@ namespace PetaPoco
         /// <remarks>
         ///     To create a ColumnInfo from a property's attributes, use PropertyInfo.FromProperty
         /// </remarks>
-        public ColumnInfo GetColumnInfo(PropertyInfo pocoProperty)
+        public virtual ColumnInfo GetColumnInfo(PropertyInfo pocoProperty)
         {
             var ci = new ColumnInfo();
             return MapColumn(ci, pocoProperty.DeclaringType, pocoProperty) ? ci : null;
@@ -209,7 +209,7 @@ namespace PetaPoco
         /// <param name="targetProperty">The target property</param>
         /// <param name="sourceType">The type of data returned by the DB</param>
         /// <returns>A Func that can do the conversion, or null for no conversion</returns>
-        public Func<object, object> GetFromDbConverter(PropertyInfo targetProperty, Type sourceType)
+        public virtual Func<object, object> GetFromDbConverter(PropertyInfo targetProperty, Type sourceType)
         {
             return FromDbConverter?.Invoke(targetProperty, sourceType);
         }
@@ -224,7 +224,7 @@ namespace PetaPoco
         ///     being Inserted or Updated.
         ///     Conversion is not available for parameter values passed directly to queries.
         /// </remarks>
-        public Func<object, object> GetToDbConverter(PropertyInfo sourceProperty)
+        public virtual Func<object, object> GetToDbConverter(PropertyInfo sourceProperty)
         {
             return ToDbConverter?.Invoke(sourceProperty);
         }


### PR DESCRIPTION
I noticed while providing an example for #527 that the `IMapper` methods in `ConventionMapper` are not marked as virtual, which makes it harder to inherit from that class. 