### PR TITLE
Force byte[] params to map to DbType.Binary

### DIFF
--- a/PetaPoco.Tests.Unit/CreateCommandTests.cs
+++ b/PetaPoco.Tests.Unit/CreateCommandTests.cs
@@ -144,5 +144,17 @@ namespace PetaPoco.Tests.Unit
             Action act = () => _db.CreateCommand(_conn, CommandType.StoredProcedure, "procname", arg);
             act.ShouldThrow<ArgumentException>();
         }
+
+        [Fact]
+        public void ByteArray_Should_Map_To_Binary()
+        {
+            var sql = Sql.Builder.Select("*").From("SomeTable");
+            sql.Where("foo=@0", new byte[] { 1, 2, 3 });
+            var output = _db.CreateCommand(_conn, sql.SQL, sql.Arguments);
+
+            output.Parameters.Count.ShouldBe(1);
+            var parm = output.Parameters[0] as IDataParameter;
+            parm.DbType.ShouldBe(DbType.Binary);
+        }
     }
 }

--- a/PetaPoco/Database.cs
+++ b/PetaPoco/Database.cs
@@ -588,7 +588,7 @@ namespace PetaPoco
                 var t = value.GetType();
                 if (t.IsEnum) // PostgreSQL .NET driver wont cast enum to int
                 {
-                    p.Value = Convert.ChangeType(value, ((Enum) value).GetTypeCode());
+                    p.Value = Convert.ChangeType(value, ((Enum)value).GetTypeCode());
                 }
                 else if (t == typeof(Guid) && !_provider.HasNativeGuidSupport)
                 {
@@ -630,6 +630,11 @@ namespace PetaPoco
                 {
                     p.GetType().GetProperty("UdtTypeName").SetValue(p, "geometry", null); //geography is the equivalent SQL Server Type
                     p.Value = value;
+                }
+                else if (t == typeof(byte[]))
+                {
+                    p.Value = value;
+                    p.DbType = DbType.Binary;
                 }
                 else
                 {

--- a/PetaPoco/Properties/launchSettings.json
+++ b/PetaPoco/Properties/launchSettings.json
@@ -1,0 +1,7 @@
+{
+  "profiles": {
+    "PetaPoco": {
+      "commandName": "Project"
+    }
+  }
+}


### PR DESCRIPTION
Relates to #562 

This was trivial to implement, but I'm not sure if we should actually do it. After looking at some more DataProviders, I see that most of them handle this kind of translation from .NET type to DbType themselves. The particular db I'm working with for some reason doesn't explicitly handle `byte[]`, which is why I was having problems. But if I can count on `DatabaseProvider.PreExecute()` being called (see other PR), then I can handle this myself in my custom `DatabaseProvider`.

So I'm perfectly fine if you want to decline this PR.