### PR TITLE
Standardize calls to PreExecute

### DIFF
--- a/PetaPoco.Tests.Integration/Databases/MSSQL/MssqlPreExecuteTests.cs
+++ b/PetaPoco.Tests.Integration/Databases/MSSQL/MssqlPreExecuteTests.cs
@@ -1,0 +1,201 @@
+﻿using PetaPoco.Providers;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Shouldly;
+
+namespace PetaPoco.Tests.Integration.Databases.MSSQL
+{
+    [Collection("Mssql")]
+    public class MssqlPreExecuteTests : BaseDatabase
+    {
+        public MsssqlPreExecuteDatabaseProvider Provider => DB.Provider as MsssqlPreExecuteDatabaseProvider;
+
+        public MssqlPreExecuteTests() : base(new MssqlPreExecuteDBTestProvider())
+        {
+            Provider.ThrowExceptions = true;
+        }
+
+
+        [Fact]
+        public void Query_Calls_PreExecute()
+        {
+            var expected = Guid.NewGuid().ToString();
+            var sql = Sql.Builder
+                .Select("*")
+                .From("sometable")
+                .Where("foo = @0", expected);
+
+            void act() => DB.Query<string>(sql).First();
+
+            Should.Throw<PreExecuteException>(act);
+            Provider.Parameters.Count().ShouldBe(1);
+            Provider.Parameters.First().Value.ShouldBe(expected);
+        }
+
+        [Fact]
+        public void Execute_Calls_PreExecute()
+        {
+            var expected = Guid.NewGuid().ToString();
+            var sql = Sql.Builder
+                .Select("*")
+                .From("sometable")
+                .Where("foo = @0", expected);
+
+            void act() => DB.Execute(sql);
+
+            Should.Throw<PreExecuteException>(act);
+            Provider.Parameters.Count().ShouldBe(1);
+            Provider.Parameters.First().Value.ShouldBe(expected);
+        }
+
+        [Fact]
+        public void Insert_Calls_PreExecute()
+        {
+            var expected = Guid.NewGuid().ToString();
+
+            void act() => DB.Insert("sometable", new { Foo = expected });
+
+            Should.Throw<PreExecuteException>(act);
+            Provider.Parameters.Count().ShouldBe(1);
+            Provider.Parameters.First().Value.ShouldBe(expected);
+        }
+
+        [Fact]
+        public void Update_Calls_PreExecute()
+        {
+            var expected = Guid.NewGuid().ToString();
+
+            void act() => DB.Update("sometable", "id", new { ID = 3, Foo = expected });
+
+            Should.Throw<PreExecuteException>(act);
+            Provider.Parameters.Count().ShouldBe(2);
+            Provider.Parameters.First().Value.ShouldBe(expected);
+        }
+
+        [Fact]
+        public void ExecuteScalar_Calls_PreExecute()
+        {
+            var expected = Guid.NewGuid().ToString();
+            var sql = Sql.Builder
+                .Select("count(*)")
+                .From("sometable")
+                .Where("foo = @0", expected);
+
+            void act() => DB.ExecuteScalar<int>(sql);
+
+            Should.Throw<PreExecuteException>(act);
+            Provider.Parameters.Count().ShouldBe(1);
+            Provider.Parameters.First().Value.ShouldBe(expected);
+        }
+
+
+        [Fact]
+        public void QueryAsync_Calls_PreExecute()
+        {
+            var expected = Guid.NewGuid().ToString();
+            var sql = Sql.Builder
+                .Select("*")
+                .From("sometable")
+                .Where("foo = @0", expected);
+
+            async Task act() => await DB.QueryAsync<string>(sql).Result.ReadAsync();
+
+            Should.Throw<PreExecuteException>(act);
+            Provider.Parameters.Count().ShouldBe(1);
+            Provider.Parameters.First().Value.ShouldBe(expected);
+        }
+
+        [Fact]
+        public void ExecuteAsync_Calls_PreExecute()
+        {
+            var expected = Guid.NewGuid().ToString();
+            var sql = Sql.Builder
+                .Select("*")
+                .From("sometable")
+                .Where("foo = @0", expected);
+
+            async Task act() => await DB.ExecuteAsync(sql);
+
+            Should.Throw<PreExecuteException>(act);
+            Provider.Parameters.Count().ShouldBe(1);
+            Provider.Parameters.First().Value.ShouldBe(expected);
+        }
+
+        [Fact]
+        public void InsertAsync_Calls_PreExecute()
+        {
+            var expected = Guid.NewGuid().ToString();
+
+            async Task act() => await DB.InsertAsync("sometable", new { Foo = expected });
+
+            Should.Throw<PreExecuteException>(act);
+            Provider.Parameters.Count().ShouldBe(1);
+            Provider.Parameters.First().Value.ShouldBe(expected);
+        }
+
+        [Fact]
+        public void UpdateAsync_Calls_PreExecute()
+        {
+            var expected = Guid.NewGuid().ToString();
+
+            async Task act() => await DB.UpdateAsync("sometable", "id", new { ID = 3, Foo = expected });
+
+            Should.Throw<PreExecuteException>(act);
+            Provider.Parameters.Count().ShouldBe(2);
+            Provider.Parameters.First().Value.ShouldBe(expected);
+        }
+
+        [Fact]
+        public void ExecuteScalarAsync_Calls_PreExecute()
+        {
+            var expected = Guid.NewGuid().ToString();
+            var sql = Sql.Builder
+                .Select("count(*)")
+                .From("sometable")
+                .Where("foo = @0", expected);
+
+            async Task act() => await DB.ExecuteScalarAsync<int>(sql);
+
+            Should.Throw<PreExecuteException>(act);
+            Provider.Parameters.Count().ShouldBe(1);
+            Provider.Parameters.First().Value.ShouldBe(expected);
+        }
+
+
+        public class MssqlPreExecuteDBTestProvider : MssqlDBTestProvider
+        {
+            protected override IDatabase LoadFromConnectionName(string name)
+            {
+                var config = BuildFromConnectionName(name);
+                config.UsingProvider<MsssqlPreExecuteDatabaseProvider>();
+                return config.Create();
+            }
+        }
+
+        public class MsssqlPreExecuteDatabaseProvider : SqlServerDatabaseProvider
+        {
+            public bool ThrowExceptions { get; set; }
+            public List<IDataParameter> Parameters { get; set; } = new List<IDataParameter>();
+
+            public override void PreExecute(IDbCommand cmd)
+            {
+                Parameters.Clear();
+
+                if (ThrowExceptions)
+                {
+                    Parameters = cmd.Parameters.Cast<IDataParameter>().ToList();
+                    throw new PreExecuteException();
+                }
+            }
+        }
+
+        public class PreExecuteException : Exception { }
+    }
+
+    
+}

--- a/PetaPoco/Core/DatabaseProvider.cs
+++ b/PetaPoco/Core/DatabaseProvider.cs
@@ -259,38 +259,16 @@ namespace PetaPoco.Core
             }
         }
 
-        protected void ExecuteNonQueryHelper(Database db, IDbCommand cmd)
-        {
-            db.DoPreExecute(cmd);
-            cmd.ExecuteNonQuery();
-            db.OnExecutedCommand(cmd);
-        }
+        protected void ExecuteNonQueryHelper(Database db, IDbCommand cmd) => db.ExecuteNonQueryHelper(cmd);
 
-        protected object ExecuteScalarHelper(Database db, IDbCommand cmd)
-        {
-            db.DoPreExecute(cmd);
-            var r = cmd.ExecuteScalar();
-            db.OnExecutedCommand(cmd);
-            return r;
-        }
+        protected object ExecuteScalarHelper(Database db, IDbCommand cmd) => db.ExecuteScalarHelper(cmd);
+
 #if ASYNC
         protected async Task ExecuteNonQueryHelperAsync(CancellationToken cancellationToken, Database db, IDbCommand cmd)
-        {
-            db.DoPreExecute(cmd);
-            if (cmd is DbCommand dbCommand)
-                await dbCommand.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-            else
-                cmd.ExecuteNonQuery();
-            db.OnExecutedCommand(cmd);
-        }
+            => db.ExecuteNonQueryHelperAsync(cancellationToken, cmd);
 
         protected async Task<object> ExecuteScalarHelperAsync(CancellationToken cancellationToken, Database db, IDbCommand cmd)
-        {
-            db.DoPreExecute(cmd);
-            var r = cmd is DbCommand dbCommand ? await dbCommand.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) : cmd.ExecuteScalar();
-            db.OnExecutedCommand(cmd);
-            return r;
-        }
+            => db.ExecuteScalarHelperAsync(cancellationToken, cmd);
 #endif
     }
 }

--- a/PetaPoco/Core/DatabaseProvider.cs
+++ b/PetaPoco/Core/DatabaseProvider.cs
@@ -264,10 +264,10 @@ namespace PetaPoco.Core
         protected object ExecuteScalarHelper(Database db, IDbCommand cmd) => db.ExecuteScalarHelper(cmd);
 
 #if ASYNC
-        protected async Task ExecuteNonQueryHelperAsync(CancellationToken cancellationToken, Database db, IDbCommand cmd)
+        protected Task ExecuteNonQueryHelperAsync(CancellationToken cancellationToken, Database db, IDbCommand cmd)
             => db.ExecuteNonQueryHelperAsync(cancellationToken, cmd);
 
-        protected async Task<object> ExecuteScalarHelperAsync(CancellationToken cancellationToken, Database db, IDbCommand cmd)
+        protected Task<object> ExecuteScalarHelperAsync(CancellationToken cancellationToken, Database db, IDbCommand cmd)
             => db.ExecuteScalarHelperAsync(cancellationToken, cmd);
 #endif
     }

--- a/PetaPoco/Database.cs
+++ b/PetaPoco/Database.cs
@@ -31,6 +31,7 @@ namespace PetaPoco
                 OneTimeCommandTimeout = 0;
             }
 
+            _provider.PreExecute(cmd);
             OnExecutingCommand(cmd);
 
             _lastSql = cmd.CommandText;
@@ -676,8 +677,6 @@ namespace PetaPoco
             foreach (var item in args)
                 AddParam(cmd, item, null);
 
-            _provider.PreExecute(cmd);
-
             if (!string.IsNullOrEmpty(sql))
                 DoPreExecute(cmd);
 
@@ -771,6 +770,7 @@ namespace PetaPoco
                 {
                     using (var cmd = CreateCommand(_sharedConnection, commandType, sql, args))
                     {
+                        DoPreExecute(cmd);
                         var rowsAffected = cmd.ExecuteNonQuery();
                         OnExecutedCommand(cmd);
                         return rowsAffected;
@@ -812,6 +812,7 @@ namespace PetaPoco
                 {
                     using (var cmd = CreateCommand(_sharedConnection, commandType, sql, args))
                     {
+                        DoPreExecute(cmd);
                         var rowsAffected = cmd is DbCommand dbCommandAsync
                             ? await dbCommandAsync.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false)
                             : cmd.ExecuteNonQuery();
@@ -855,6 +856,7 @@ namespace PetaPoco
                 {
                     using (var cmd = CreateCommand(_sharedConnection, commandType, sql, args))
                     {
+                        DoPreExecute(cmd);
                         var val = cmd.ExecuteScalar();
                         OnExecutedCommand(cmd);
 
@@ -907,6 +909,7 @@ namespace PetaPoco
                 {
                     using (var cmd = CreateCommand(_sharedConnection, commandType, sql, args))
                     {
+                        DoPreExecute(cmd);
                         var val = cmd is DbCommand cmdAsync ? await cmdAsync.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) : cmd.ExecuteScalar();
                         OnExecutedCommand(cmd);
 
@@ -1369,6 +1372,7 @@ namespace PetaPoco
 
                     try
                     {
+                        DoPreExecute(cmd);
                         if (cmdAsync != null)
                             reader = await cmdAsync.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
                         else
@@ -1434,6 +1438,7 @@ namespace PetaPoco
 
             try
             {
+                DoPreExecute(cmd);
                 if (cmd is DbCommand cmdAsync)
                     reader = await cmdAsync.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
                 else
@@ -1477,6 +1482,7 @@ namespace PetaPoco
                     var pd = PocoData.ForType(typeof(T), _defaultMapper);
                     try
                     {
+                        DoPreExecute(cmd);
                         r = cmd.ExecuteReader();
                         OnExecutedCommand(cmd);
                     }
@@ -2720,6 +2726,7 @@ namespace PetaPoco
                     IDataReader r;
                     try
                     {
+                        DoPreExecute(cmd);
                         r = cmd.ExecuteReader();
                         OnExecutedCommand(cmd);
                     }
@@ -2792,7 +2799,9 @@ namespace PetaPoco
 
             try
             {
+                DoPreExecute(cmd);
                 var reader = cmd.ExecuteReader();
+                OnExecutedCommand(cmd);
                 result = new GridReader(this, cmd, reader, _defaultMapper);
             }
             catch (Exception x)


### PR DESCRIPTION
Relates to #562 

I started out just moving the call to `_provider.PreExecute()` into `Database.DoPreExecute()`, but then I saw that the usage pattern around calling that wasn't consistent either. I wound up consolidating the pattern in a few helper classes in `Database`.

I wasn't able to write unit tests to verify that `PreExecute()` always gets called because there were elements of the process that I couldn't figure out how to mock. So I did write a set of integration tests, which aren't really integration tests because they never use the database -- but the tests needed a live `Connection` to work with. They make use of a custom `DatabaseProvider` which records the parameters it sees and then throws an exception to abort the database action; this way the tests can verify that `PreExecute()` was called and had access to the parameters on the command.

This bunch of tests is implemented only within the MsSql collection. I didn't implement them for all db types because, as I said, the tests don't ultimately rely on communication with the db aside from opening the connection, and because there are a few different custom classes required. But if you think it's important to maintain parity, I'm happy to spend some time refactoring to get the tests into all the db collections.