### PR TITLE
KeyNotFoundException with concise message

### DIFF
--- a/PetaPoco.Tests.Unit/Core/EnumMapperTest.cs
+++ b/PetaPoco.Tests.Unit/Core/EnumMapperTest.cs
@@ -1,0 +1,49 @@
+﻿using PetaPoco.Internal;
+using Shouldly;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PetaPoco.Tests.Unit.Core
+{
+    public class EnumMapperTest
+    {
+        [Fact]
+        public void Mapping_ExistingEnum_Ok()
+        {
+            var expected = FakeEnum.ExistingValue;
+            var enumType = expected.GetType();
+            var name = Enum.GetName(enumType, expected);
+
+            var actual = EnumMapper.EnumFromString(enumType, name);
+
+            actual.ShouldBe(expected);
+        }
+
+        [Fact]
+        public void Mapping_NonExistingEnum_ThrowsMeaningfulException()
+        {
+            var enumType = typeof(FakeEnum);
+            var nonExistentName = "ThisValueDoesNotExistOnAnyEnum";
+
+            try
+            {
+                EnumMapper.EnumFromString(enumType, nonExistentName);
+            }
+            catch (InvalidOperationException ex)
+            {
+                var message = ex.Message;
+                message.ShouldContain(nonExistentName, "missing value to convert");
+                message.ShouldContain(enumType.Name, "missing Enum to convert into");
+                return;
+            }
+
+            Assert.False(true, "Expedted InvalidOperationException");
+        }
+
+        private enum FakeEnum
+        {
+            ExistingValue
+        }
+    }
+}

--- a/PetaPoco.Tests.Unit/Core/EnumMapperTest.cs
+++ b/PetaPoco.Tests.Unit/Core/EnumMapperTest.cs
@@ -1,7 +1,7 @@
 ﻿using PetaPoco.Internal;
 using Shouldly;
 using System;
-using System.Threading.Tasks;
+using System.Collections.Generic;
 using Xunit;
 
 namespace PetaPoco.Tests.Unit.Core
@@ -30,7 +30,7 @@ namespace PetaPoco.Tests.Unit.Core
             {
                 EnumMapper.EnumFromString(enumType, nonExistentName);
             }
-            catch (InvalidOperationException ex)
+            catch (KeyNotFoundException ex)
             {
                 var message = ex.Message;
                 message.ShouldContain(nonExistentName, "missing value to convert");

--- a/PetaPoco/Utilities/EnumMapper.cs
+++ b/PetaPoco/Utilities/EnumMapper.cs
@@ -27,10 +27,11 @@ namespace PetaPoco.Internal
             {
                 return map[value];
             }
-            catch (KeyNotFoundException)
+            catch (KeyNotFoundException inner)
             {
-                throw new InvalidOperationException(
-                    string.Format("Can not convert value `{0}` into {1}-Enum", value, enumType.Name));
+                throw new KeyNotFoundException(
+                    $"Requested value '{value}' was not found in enum {enumType.Name}.",
+                    inner);
             }
         }
     }

--- a/PetaPoco/Utilities/EnumMapper.cs
+++ b/PetaPoco/Utilities/EnumMapper.cs
@@ -23,7 +23,15 @@ namespace PetaPoco.Internal
                 return newmap;
             });
 
-            return map[value];
+            try
+            {
+                return map[value];
+            }
+            catch (KeyNotFoundException)
+            {
+                throw new InvalidOperationException(
+                    string.Format("Can not convert value `{0}` into {1}-Enum", value, enumType.Name));
+            }
         }
     }
 }


### PR DESCRIPTION
catches KeyNotFoundException and throws InvalidOperationException containing the invalid value and the Enum-Name in which the value should have been mapped.