### PR TITLE
Add some syntactic sugar to AnsiString

### DIFF
--- a/PetaPoco.Tests.Unit/Core/AnsiStringTests.cs
+++ b/PetaPoco.Tests.Unit/Core/AnsiStringTests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Shouldly;
+using PetaPoco;
+
+namespace PetaPoco.Tests.Unit.Core
+{
+    public class AnsiStringTests
+    {
+        [Fact]
+        public void Constructor_Returns_Valid_Object()
+        {
+            var input = "Some string value";
+            var output = new AnsiString(input);
+
+            output.ShouldBeOfType<AnsiString>();
+            output.Value.ShouldBe(input);
+        }
+
+        [Fact]
+        public void Explicit_Conversion_Works()
+        {
+            var input = "An ordinary string value";
+            var output = (AnsiString)input;
+
+            output.ShouldBeOfType<AnsiString>();
+            output.Value.ShouldBe(input);
+        }
+
+        [Theory]
+        [InlineData(typeof(object))]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(List<string>))]
+        public void Explicit_Conversion_Non_Strings_Should_Throw(Type type)
+        {
+            var input = Activator.CreateInstance(type);
+            Action act = () => { var output = (AnsiString)input; };
+            act.ShouldThrow<InvalidCastException>();
+        }
+
+        [Theory]
+        [InlineData("njkasnd")]
+        [InlineData(4720)]
+        [InlineData(567.234)]
+        public void Extension_Method_Works(object input)
+        {
+            var output = input.ToAnsiString();
+
+            output.ShouldBeOfType<AnsiString>();
+            output.Value.ShouldBe(input.ToString());
+        }
+    }
+}

--- a/PetaPoco/Core/AnsiString.cs
+++ b/PetaPoco/Core/AnsiString.cs
@@ -16,5 +16,7 @@
         /// <param name="str">The C# string to be converted to ANSI before being passed to the DB</param>
         public AnsiString(string str)
             => Value = str;
+
+        public static explicit operator AnsiString(string s) => new AnsiString(s);
     }
 }

--- a/PetaPoco/Core/AnsiStringExtensions.cs
+++ b/PetaPoco/Core/AnsiStringExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PetaPoco
+{
+    public static class AnsiStringExtensions
+    {
+        /// <summary>
+        /// Converts an object to its <see cref="AnsiString"/> representation
+        /// </summary>
+        /// <param name="o">The object to be converted</param>
+        /// <returns></returns>
+        public static AnsiString ToAnsiString(this object o) => new AnsiString(o.ToString());
+    }
+}


### PR DESCRIPTION
I'm working with some databases that use `varchar` instead of `nvarchar`, and I've been finding it awkward to have to use `new AnsiString("foo")` to define parameters in order to force `DbType.AnsiString`. I thought it would be helpful to add some alternate syntaxes.

These are all equivalent:

```csharp
var newObject = new AnsiString("foo");  // existing
var explicitCast = (AnsiString)"bar";   // new -- can only cast strings
var extensionMethod = "baz".ToAnsiString();    // new -- works on any object, just like ToString()
```