### PR TITLE
iOS compatibility changes

### DIFF
--- a/PetaPoco/Database.cs
+++ b/PetaPoco/Database.cs
@@ -1371,9 +1371,8 @@ namespace PetaPoco
                     }
 
                     var readerAsync = reader as DbDataReader;
-                    var factory =
-                        pd.GetFactory(cmd.CommandText, _sharedConnection.ConnectionString, 0, reader.FieldCount, reader,
-                            _defaultMapper) as Func<IDataReader, T>;
+                    var factory = pd.PocoFactory<T>(cmd.CommandText, _sharedConnection.ConnectionString, 0, reader.FieldCount, reader,
+                        _defaultMapper) as Func<IDataReader, T>;
 
                     using (reader)
                     {
@@ -1441,8 +1440,8 @@ namespace PetaPoco
                 return AsyncReader<T>.Empty();
             }
 
-            var factory =
-                pd.GetFactory(cmd.CommandText, _sharedConnection.ConnectionString, 0, reader.FieldCount, reader, _defaultMapper) as Func<IDataReader, T>;
+            var factory = pd.PocoFactory<T>(cmd.CommandText, _sharedConnection.ConnectionString, 0, reader.FieldCount, reader,
+                _defaultMapper) as Func<IDataReader, T>;
 
             return new AsyncReader<T>(this, cmd, reader, factory);
         }
@@ -1469,7 +1468,7 @@ namespace PetaPoco
                         yield break;
                     }
 
-                    var factory = pd.GetFactory(cmd.CommandText, _sharedConnection.ConnectionString, 0, r.FieldCount, r,
+                    var factory = pd.PocoFactory<T>(cmd.CommandText, _sharedConnection.ConnectionString, 0, r.FieldCount, r,
                         _defaultMapper) as Func<IDataReader, T>;
                     using (r)
                     {


### PR DESCRIPTION
Add alternate non-IL Factory method to PocoData.cs. This is usable under iOS (under Xamarin), which blocks IL generation and some reflection operations.

These changes are a first iteration. They are tested on iOS, but use only the commonly used PetaPoco features.

Because the error is runtime and not compile time, we may wish to add a configuration option to allow use with either code path. This depends on if the non-iOS compatible path yields significant performance improvements (I would imagine this is why it was moved to IL).

Also, MultiPocoFactory.cs has a CreateMultiPocoFactory method (and perhaps GetAutoMapper) which would need to be converted for complete coverage. I've never used the MultiPoco feature before and thought I'd test the waters as to how essential that is before I leap into another half day of trying to back-convert IL.