### PR TITLE
Improve resilience of MultiPoco queries to database schema changes

### DIFF
--- a/PetaPoco/Core/MultiPocoFactory.cs
+++ b/PetaPoco/Core/MultiPocoFactory.cs
@@ -11,7 +11,7 @@ namespace PetaPoco.Internal
     internal class MultiPocoFactory
     {
         // Various cached stuff
-        private static readonly Cache<Tuple<Type, ArrayKey<Type>, string, string>, object> MultiPocoFactories = new Cache<Tuple<Type, ArrayKey<Type>, string, string>, object>();
+        private static readonly Cache<Tuple<Type, ArrayKey<Type>, string, string, int>, object> MultiPocoFactories = new Cache<Tuple<Type, ArrayKey<Type>, string, string, int>, object>();
 
         private static readonly Cache<ArrayKey<Type>, object> AutoMappers = new Cache<ArrayKey<Type>, object>();
 
@@ -142,7 +142,7 @@ namespace PetaPoco.Internal
         // Get (or create) the multi-poco factory for a query
         public static Func<IDataReader, object, TRet> GetFactory<TRet>(Type[] types, string connectionString, string sql, IDataReader r, IMapper defaultMapper)
         {
-            var key = Tuple.Create(typeof(TRet), new ArrayKey<Type>(types), connectionString, sql);
+            var key = Tuple.Create(typeof(TRet), new ArrayKey<Type>(types), connectionString, sql, r.FieldCount);
 
             return (Func<IDataReader, object, TRet>) MultiPocoFactories.Get(key, () => CreateMultiPocoFactory<TRet>(types, connectionString, sql, r, defaultMapper));
         }


### PR DESCRIPTION
Partly addresses the problem raised in https://github.com/CollaboratingPlatypus/PetaPoco/issues/617

This will ensure cached poco factories are only used if the number of columns returned by the query has not been changed. This is not foolproof, as columns may have been added to one table and removed from another, but it seems like a worthwhile improvement.

NB: I only have SQLite on my local machine, so would appreciate it if someone could fix the test to work with other databases if necessary.