### PR TITLE
Allow dictionaries to be passed with parameters

### DIFF
--- a/PetaPoco.Tests.Unit/Utilities/ParametersHelperTests.cs
+++ b/PetaPoco.Tests.Unit/Utilities/ParametersHelperTests.cs
@@ -1,5 +1,12 @@
-﻿using PetaPoco.Internal;
+﻿using Moq;
+using PetaPoco.Internal;
 using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Reflection;
 using Xunit;
 
 namespace PetaPoco.Tests.Unit.Utilities
@@ -35,6 +42,109 @@ namespace PetaPoco.Tests.Unit.Utilities
             var expected = $"This {prefix}foo is {prefix}bar";
             var output = input.ReplaceParamPrefix(prefix);
             output.ShouldBe(expected);
+        }
+
+        [Fact]
+        public void ProcessQueryParams_PositionalParams_ShouldWork()
+        {
+            var sql = "select * from foo where a = @0 and b = @1";
+            var args_src = new object[] { 5, "bird" };
+            var args_dest = new List<object>();
+            var output = ParametersHelper.ProcessQueryParams(sql, args_src, args_dest);
+
+            output.ShouldBe(sql);
+            args_dest.ShouldBe(args_src.ToList());
+        }
+
+        private void NamedQueryParamsTestHelper(object[] args_src)
+        {
+            var sql = "select * from foo where a = @first and b = @second";
+            var args_dest = new List<object>();
+
+            var expected_sql = "select * from foo where a = @0 and b = @1";
+            var expected_args = new List<object>() { 87, "Bob" };
+
+            var output = ParametersHelper.ProcessQueryParams(sql, args_src, args_dest);
+
+            output.ShouldBe(expected_sql);
+            args_dest.ShouldBe(expected_args);
+        }
+
+        [Fact]
+        public void ProcessQueryParams_ObjectWithProperties_ShouldWork()
+        {
+            var args_src = new[] { new { second = "Bob", first = 87 } };
+            NamedQueryParamsTestHelper(args_src);
+        }
+
+        [Fact]
+        public void ProcessQueryParams_Dictionary_ShouldWork()
+        {
+            var args_src = new[] { new Dictionary<string, object> { ["second"] = "Bob", ["first"] = 87 } };
+            NamedQueryParamsTestHelper(args_src);
+        }
+
+        [Fact]
+        public void ProcessQueryParams_DictionaryAndObject_ShouldWork()
+        {
+            var args_src = new object[] { new Dictionary<string, object> { ["second"] = "Bob" }, new { first = 87 } };
+            NamedQueryParamsTestHelper(args_src);
+        }
+
+        [Fact]
+        public void ProcessQueryParams_MissingParam_ShouldThrow()
+        {
+            var args_src = new[] { new {first = 87 } };
+            Action act = () => NamedQueryParamsTestHelper(args_src);
+
+            var ex = act.ShouldThrow<ArgumentException>();
+            ex.Message.ShouldMatch(@"^Parameter '@second' specified");
+        }
+
+        private void NamedProcParamsTestHelper(object[] args_src)
+        {
+            Action<IDbDataParameter, object, PropertyInfo> setAction = (p, o, pi) => p.Value = o;
+            var cmd = new SqlCommand();
+
+            var expected = new [] { new SqlParameter("foo", 42), new SqlParameter("bar", "Dirk Gently") };
+            var output = ParametersHelper.ProcessStoredProcParams(cmd, args_src, setAction)
+                .Cast<IDbDataParameter>()
+                .ToArray();
+
+            output.Count().ShouldBe(2);
+            output[0].ParameterName.ShouldBe(expected[0].ParameterName);
+            output[0].Value.ShouldBe(expected[0].Value);
+            output[1].ParameterName.ShouldBe(expected[1].ParameterName);
+            output[1].Value.ShouldBe(expected[1].Value);
+
+        }
+
+        [Fact]
+        public void ProcessStoredProcParams_Parameter_ShouldWork()
+        {
+            var args_src = new object[] { new SqlParameter("foo", 42), new SqlParameter("bar", "Dirk Gently") };
+            NamedProcParamsTestHelper(args_src);
+        }
+
+        [Fact]
+        public void ProcessStoredProcParams_ObjectWithProperties_ShouldWork()
+        {
+            var args_src = new object[] { new { foo = 42, bar = "Dirk Gently" } };
+            NamedProcParamsTestHelper(args_src);
+        }
+
+        [Fact]
+        public void ProcessStoredProcParams_Dictionary_ShouldWork()
+        {
+            var args_src = new[] { new Dictionary<string, object>() { ["foo"] = 42, ["bar"] = "Dirk Gently" } };
+            NamedProcParamsTestHelper(args_src);
+        }
+
+        [Fact]
+        public void ProcessStoredProcParams_DictionaryAndObject_ShouldWork()
+        {
+            var args_src = new object[] { new Dictionary<string, object>() { ["foo"] = 42 }, new { bar = "Dirk Gently" } };
+            NamedProcParamsTestHelper(args_src);
         }
     }
 }


### PR DESCRIPTION
We can currently pass in POCOs that hold parameter values (for queries and stored procs) and PP will turn them into arrays of parameters. This PR lets us pass in Dictionaries as well.

```c#
db.Query(sql, new { Foo = 5, Bar = "apple" });

// same as 
var dict = new Dictionary<string, object>()
{
    ["Foo"] = 5,
    ["Bar"] = "apple"
}
db.Query(sql, dict);
```

The reason for this is that it lets you build up a collection of arbitrarily named parameters.