### PR TITLE
Allow null values in dictionaries

### DIFF
--- a/PetaPoco.Tests.Unit/Utilities/ParametersHelperTests.cs
+++ b/PetaPoco.Tests.Unit/Utilities/ParametersHelperTests.cs
@@ -92,13 +92,55 @@ namespace PetaPoco.Tests.Unit.Utilities
         }
 
         [Fact]
-        public void ProcessQueryParams_MissingParam_ShouldThrow()
+        public void ProcessQueryParams_ObjectMissingParam_ShouldThrow()
         {
             var args_src = new[] { new {first = 87 } };
             Action act = () => NamedQueryParamsTestHelper(args_src);
 
             var ex = act.ShouldThrow<ArgumentException>();
             ex.Message.ShouldMatch(@"^Parameter '@second' specified");
+        }
+
+        [Fact]
+        public void ProcessQueryParams_DictionaryMissingParam_ShouldThrow()
+        {
+            var args_src = new[] { new Dictionary<string, object>() { ["first"] = 87 } };
+            Action act = () => NamedQueryParamsTestHelper(args_src);
+
+            var ex = act.ShouldThrow<ArgumentException>();
+            ex.Message.ShouldMatch(@"^Parameter '@second' specified");
+        }
+
+        [Fact]
+        public void ProcessQueryParams_ObjectWithNull_ShouldWork()
+        {
+            var sql = "select * from foo where a = @first";
+            var args_src = new[] { new { first = (string)null } };
+            var args_dest = new List<object>();
+
+            var expected_sql = "select * from foo where a = @0";
+            var expected_args = new List<object>() { null };
+
+            var output = ParametersHelper.ProcessQueryParams(sql, args_src, args_dest);
+
+            output.ShouldBe(expected_sql);
+            args_dest.ShouldBe(expected_args);
+        }
+
+        [Fact]
+        public void ProcessQueryParams_DictionaryWithNull_ShouldWork()
+        {
+            var sql = "select * from foo where a = @first";
+            var args_src = new[] { new Dictionary<string, object>() { ["first"] = null } };
+            var args_dest = new List<object>();
+
+            var expected_sql = "select * from foo where a = @0";
+            var expected_args = new List<object>() { null };
+
+            var output = ParametersHelper.ProcessQueryParams(sql, args_src, args_dest);
+
+            output.ShouldBe(expected_sql);
+            args_dest.ShouldBe(expected_args);
         }
 
         private void NamedProcParamsTestHelper(object[] args_src)

--- a/PetaPoco/Utilities/ParametersHelper.cs
+++ b/PetaPoco/Utilities/ParametersHelper.cs
@@ -59,15 +59,11 @@ namespace PetaPoco.Internal
                         {
                             Type[] arguments = dict.GetType().GetGenericArguments();
 
-                            if (arguments[0] == typeof(string))
+                            if (arguments[0] == typeof(string) && dict.Contains(param))
                             {
-                                var val = dict[param];
-                                if (val != null)
-                                {
-                                    found = true;
-                                    arg_val = val;
-                                    break;
-                                }
+                                arg_val = dict[param];
+                                found = true;
+                                break;                                
                             }
                         }
 


### PR DESCRIPTION
In `IDictionary`, `dict[item]` returns null if the key doesn't exist, which is different behavior from the generic `IDictionary<TKey, TValue>`. We want to separate the check for the key from retrieving the value, because we do want to allow through null values -- as we currently do with object properties. (They're converted to `DBNull.Value` in `Database.SetParameterValues()`.