### PR TITLE
ansi and datetime2 fix

### DIFF
--- a/PetaPoco/Attributes/ColumnAttribute.cs
+++ b/PetaPoco/Attributes/ColumnAttribute.cs
@@ -38,11 +38,11 @@ namespace PetaPoco
         /// <summary>
         ///     True if AnsiString / VARCHAR column
         /// </summary>
-        public bool IsAnsi { get; set; }
+        public bool ForceToAnsiString { get; set; }
         /// <summary>
         ///     True if DateTime2 column
         /// </summary>
-        public bool IsDateTime2 { get; set; }
+        public bool ForceToDateTime2 { get; set; }
 
         /// <summary>
         ///     Constructs a new instance of the <seealso cref="ColumnAttribute" />.

--- a/PetaPoco/Attributes/ColumnAttribute.cs
+++ b/PetaPoco/Attributes/ColumnAttribute.cs
@@ -35,6 +35,14 @@ namespace PetaPoco
         ///     json)"
         /// </summary>
         public string UpdateTemplate { get; set; }
+        /// <summary>
+        ///     True if AnsiString / VARCHAR column
+        /// </summary>
+        public bool IsAnsi { get; set; }
+        /// <summary>
+        ///     True if DateTime2 column
+        /// </summary>
+        public bool IsDateTime2 { get; set; }
 
         /// <summary>
         ///     Constructs a new instance of the <seealso cref="ColumnAttribute" />.

--- a/PetaPoco/Core/ColumnInfo.cs
+++ b/PetaPoco/Core/ColumnInfo.cs
@@ -35,6 +35,14 @@ namespace PetaPoco
         ///     is simply set to DateTimeKind.Utc instead of DateTimeKind.Unknown.
         /// </summary>
         public bool ForceToUtc { get; set; }
+        /// <summary>
+        ///     True if Database Column is DbType.AnsiString (like VARCHAR)
+        /// </summary>
+        public bool ForceToAnsiString { get; set; }
+        /// <summary>
+        ///     True if Database Colume is DbType.DateTime2
+        /// </summary>
+        public bool ForceToDateTime2 { get; set; }
 
         /// <summary>
         ///     The insert template. If not null, this template is used for generating the insert section instead of the deafult
@@ -70,6 +78,8 @@ namespace PetaPoco
 
                 ci.ColumnName = columnAttr?.Name ?? pi.Name;
                 ci.ForceToUtc = columnAttr?.ForceToUtc == true;
+                ci.ForceToAnsiString = columnAttr?.ForceToAnsiString == true;
+                ci.ForceToDateTime2 = columnAttr?.ForceToDateTime2 == true;
                 ci.InsertTemplate = columnAttr?.InsertTemplate;
                 ci.UpdateTemplate = columnAttr?.UpdateTemplate;
 

--- a/PetaPoco/Core/DateTime2.cs
+++ b/PetaPoco/Core/DateTime2.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace PetaPoco
+{
+    /// <summary>
+    ///     Wrap strings in an instance of this class to force use of DBType.DateTime2
+    /// </summary>
+    public class DateTime2
+    {
+        /// <summary>
+        ///     The DateTime value
+        /// </summary>
+        public DateTime Value { get; }
+
+        /// <summary>
+        ///     Constructs an DateTime2
+        /// </summary>
+        /// <param name="str">The C# string to be converted to ANSI before being passed to the DB</param>
+        public DateTime2(DateTime str)
+            => Value = str;
+    }
+}

--- a/PetaPoco/Core/DateTime2.cs
+++ b/PetaPoco/Core/DateTime2.cs
@@ -3,7 +3,7 @@
 namespace PetaPoco
 {
     /// <summary>
-    ///     Wrap strings in an instance of this class to force use of DBType.DateTime2
+    ///     Wrap DateTime in an instance of this class to force use of DBType.DateTime2
     /// </summary>
     public class DateTime2
     {
@@ -15,8 +15,10 @@ namespace PetaPoco
         /// <summary>
         ///     Constructs an DateTime2
         /// </summary>
-        /// <param name="str">The C# string to be converted to ANSI before being passed to the DB</param>
-        public DateTime2(DateTime str)
-            => Value = str;
+        /// <param name="dt">The C# DateTime to be converted to DateTime2 before being passed to the DB</param>
+        public DateTime2(DateTime dt)
+            => Value = dt;
+
+        public static explicit operator DateTime2(DateTime dt) => new DateTime2(dt);
     }
 }

--- a/PetaPoco/Core/DateTime2Extensions.cs
+++ b/PetaPoco/Core/DateTime2Extensions.cs
@@ -10,5 +10,11 @@ namespace PetaPoco
         /// <param name="o">The object to be converted</param>
         /// <returns></returns>
         public static DateTime2 ToDateTime2(this object o) => new DateTime2((DateTime)o);
+        /// <summary>
+        /// Parse a string to its <see cref="DateTime2"/> representation
+        /// </summary>
+        /// <param name="inputStr">The string to be converted</param>
+        /// <returns></returns>
+        public static DateTime2 ToDateTime2(this string inputStr) => new DateTime2(DateTime.Parse(inputStr));
     }
 }

--- a/PetaPoco/Core/DateTime2Extensions.cs
+++ b/PetaPoco/Core/DateTime2Extensions.cs
@@ -2,7 +2,7 @@
 
 namespace PetaPoco
 {
-    public static class DateTime2Extentions
+    public static class DateTime2Extensions
     {
         /// <summary>
         /// Converts an object to its <see cref="DateTime2"/> representation

--- a/PetaPoco/Core/DateTime2Extensions.cs
+++ b/PetaPoco/Core/DateTime2Extensions.cs
@@ -5,11 +5,11 @@ namespace PetaPoco
     public static class DateTime2Extensions
     {
         /// <summary>
-        /// Converts an object to its <see cref="DateTime2"/> representation
+        /// Converts an DateTime to its <see cref="DateTime2"/> representation
         /// </summary>
-        /// <param name="o">The object to be converted</param>
+        /// <param name="dt">The DateTime to be converted</param>
         /// <returns></returns>
-        public static DateTime2 ToDateTime2(this object o) => new DateTime2((DateTime)o);
+        public static DateTime2 ToDateTime2(this DateTime dt) => new DateTime2(dt);
         /// <summary>
         /// Parse a string to its <see cref="DateTime2"/> representation
         /// </summary>

--- a/PetaPoco/Core/DateTime2Extentions.cs
+++ b/PetaPoco/Core/DateTime2Extentions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace PetaPoco
+{
+    public static class DateTime2Extentions
+    {
+        /// <summary>
+        /// Converts an object to its <see cref="DateTime2"/> representation
+        /// </summary>
+        /// <param name="o">The object to be converted</param>
+        /// <returns></returns>
+        public static DateTime2 ToDateTime2(this object o) => new DateTime2((DateTime)o);
+    }
+}

--- a/PetaPoco/Core/PocoColumn.cs
+++ b/PetaPoco/Core/PocoColumn.cs
@@ -8,6 +8,8 @@ namespace PetaPoco.Core
         public bool AutoSelectedResultColumn;
         public string ColumnName;
         public bool ForceToUtc;
+        public bool ForceToAnsiString;
+        public bool ForceToDateTime2;
         public PropertyInfo PropertyInfo;
         public bool ResultColumn;
         public string InsertTemplate { get; set; }

--- a/PetaPoco/Core/PocoData.cs
+++ b/PetaPoco/Core/PocoData.cs
@@ -60,6 +60,8 @@ namespace PetaPoco.Core
                 pc.ResultColumn = ci.ResultColumn;
                 pc.AutoSelectedResultColumn = ci.AutoSelectedResultColumn;
                 pc.ForceToUtc = ci.ForceToUtc;
+                pc.ForceToAnsiString = ci.ForceToAnsiString;
+                pc.ForceToDateTime2 = ci.ForceToDateTime2;
                 pc.InsertTemplate = ci.InsertTemplate;
                 pc.UpdateTemplate = ci.UpdateTemplate;
 

--- a/PetaPoco/Database.cs
+++ b/PetaPoco/Database.cs
@@ -625,8 +625,8 @@ namespace PetaPoco
         private void SetParameterProperties(IDbDataParameter p, object value, PropertyInfo pi)
         {
             var columnAttribInfo = pi?.GetCustomAttributes(typeof(ColumnAttribute), true).FirstOrDefault() as ColumnAttribute;
-            var isAnsi = columnAttribInfo?.IsAnsi == true;
-            var isDateTime2 = columnAttribInfo?.IsDateTime2 == true;
+            var isAnsi = columnAttribInfo?.ForceToAnsiString == true;
+            var isDateTime2 = columnAttribInfo?.ForceToDateTime2 == true;
 
             // Assign the parameter value
             if (value == null)

--- a/PetaPoco/Database.cs
+++ b/PetaPoco/Database.cs
@@ -691,15 +691,8 @@ namespace PetaPoco
                 }
                 else if (t == typeof(DateTime2))
                 {
-                    var dt2Value = (value as DateTime2).Value;
-                    if (dt2Value == null)
-                    {
-                        p.Value = DBNull.Value;
-                    }
-                    else
-                    {
-                        p.Value = dt2Value;
-                    }
+                    var dt2Value = (value as DateTime2)?.Value;
+                    p.Value = dt2Value ?? (object)DBNull.Value;
                     p.DbType = DbType.DateTime2;
                 }
                 else if (value.GetType().Name == "SqlGeography") //SqlGeography is a CLR Type

--- a/PetaPoco/Database.cs
+++ b/PetaPoco/Database.cs
@@ -647,7 +647,7 @@ namespace PetaPoco
                 if (t == typeof(DateTime) && pc?.ForceToDateTime2 == true)
                 {
                     t = typeof(DateTime2);
-                    value = value.ToDateTime2();
+                    value = ((DateTime)value).ToDateTime2();
                 }
 
                 if (t.IsEnum) // PostgreSQL .NET driver wont cast enum to int

--- a/PetaPoco/Database.cs
+++ b/PetaPoco/Database.cs
@@ -625,8 +625,8 @@ namespace PetaPoco
         private void SetParameterProperties(IDbDataParameter p, object value, PropertyInfo pi)
         {
             var columnAttribInfo = pi?.GetCustomAttributes(typeof(ColumnAttribute), true).FirstOrDefault() as ColumnAttribute;
-            var isAnsi = columnAttribInfo?.ForceToAnsiString == true;
-            var isDateTime2 = columnAttribInfo?.ForceToDateTime2 == true;
+            var forceToAnsiString = columnAttribInfo?.ForceToAnsiString == true;
+            var forceToDateTime2 = columnAttribInfo?.ForceToDateTime2 == true;
 
             // Assign the parameter value
             if (value == null)
@@ -643,12 +643,12 @@ namespace PetaPoco
 
                 var t = value.GetType();
 
-                if (t == typeof(string) && isAnsi == true)
+                if (t == typeof(string) && forceToAnsiString == true)
                 {
                     t = typeof(AnsiString);
                     value = value.ToAnsiString();
                 }
-                if (t == typeof(DateTime) && isDateTime2 == true)
+                if (t == typeof(DateTime) && forceToDateTime2 == true)
                 {
                     t = typeof(DateTime2);
                     value = value.ToDateTime2();
@@ -691,14 +691,14 @@ namespace PetaPoco
                 }
                 else if (t == typeof(DateTime2))
                 {
-                    var asValue = (value as DateTime2).Value;
-                    if (asValue == null)
+                    var dt2Value = (value as DateTime2).Value;
+                    if (dt2Value == null)
                     {
                         p.Value = DBNull.Value;
                     }
                     else
                     {
-                        p.Value = asValue;
+                        p.Value = dt2Value;
                     }
                     p.DbType = DbType.DateTime2;
                 }

--- a/PetaPoco/Utilities/ParametersHelper.cs
+++ b/PetaPoco/Utilities/ParametersHelper.cs
@@ -107,7 +107,7 @@ namespace PetaPoco.Internal
             return (input as System.Collections.IEnumerable) != null && (input as string) == null && (input as byte[]) == null;
         }
 
-        public static object[] ProcessStoredProcParams(IDbCommand cmd, object[] args, Action<IDbDataParameter, object, PropertyInfo, PocoColumn> setParameterProperties)
+        public static object[] ProcessStoredProcParams(IDbCommand cmd, object[] args, Action<IDbDataParameter, object, PocoColumn> setParameterProperties)
         {
             // For a stored proc, we assume that we're only getting POCOs or parameters
             var result = new List<IDbDataParameter>();
@@ -152,7 +152,7 @@ namespace PetaPoco.Internal
             {
                 var param = cmd.CreateParameter();
                 param.ParameterName = name;
-                setParameterProperties(param, value, null, null);
+                setParameterProperties(param, value, null);
                 result.Add(param);
             }
 

--- a/PetaPoco/Utilities/ParametersHelper.cs
+++ b/PetaPoco/Utilities/ParametersHelper.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using PetaPoco.Core;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Data;
@@ -106,7 +107,7 @@ namespace PetaPoco.Internal
             return (input as System.Collections.IEnumerable) != null && (input as string) == null && (input as byte[]) == null;
         }
 
-        public static object[] ProcessStoredProcParams(IDbCommand cmd, object[] args, Action<IDbDataParameter, object, PropertyInfo> setParameterProperties)
+        public static object[] ProcessStoredProcParams(IDbCommand cmd, object[] args, Action<IDbDataParameter, object, PropertyInfo, PocoColumn> setParameterProperties)
         {
             // For a stored proc, we assume that we're only getting POCOs or parameters
             var result = new List<IDbDataParameter>();
@@ -151,7 +152,7 @@ namespace PetaPoco.Internal
             {
                 var param = cmd.CreateParameter();
                 param.ParameterName = name;
-                setParameterProperties(param, value, null);
+                setParameterProperties(param, value, null, null);
                 result.Add(param);
             }
 


### PR DESCRIPTION
the normal AnsiString fix is fine for Fetch<> ...
var test = db.FirstOrDefault<TABLE>("where NAME = @0", new AnsiString("YOURNAME"));

but for Update and Insert i cant use AnsiString 
test.SOMEDATETIME2COLUMN = DateTime.Now();
test.SOMESTRINGCOLUMN = "Hello";
test.Update() 

my new model looks like this
[Column("SOMEDATETIME2COLUMN", IsDateTime2 = true)] public DateTime? SOMEDATETIME2COLUMN { get; set;}
[Column("SOMESTRINGCOLUMN", IsAnsi = true)] public string SOMESTRINGCOLUMN { get; set;}

