### PR TITLE
Fix unit test

### DIFF
--- a/PetaPoco.Tests.Unit/Utilities/ParametersHelperTests.cs
+++ b/PetaPoco.Tests.Unit/Utilities/ParametersHelperTests.cs
@@ -1,4 +1,5 @@
 ﻿using Moq;
+using PetaPoco.Core;
 using PetaPoco.Internal;
 using Shouldly;
 using System;
@@ -145,7 +146,7 @@ namespace PetaPoco.Tests.Unit.Utilities
 
         private void NamedProcParamsTestHelper(object[] args_src)
         {
-            Action<IDbDataParameter, object, PropertyInfo> setAction = (p, o, pi) => p.Value = o;
+            Action<IDbDataParameter, object, PocoColumn> setAction = (p, o, pc) => p.Value = o;
             var cmd = new SqlCommand();
 
             var expected = new [] { new SqlParameter("foo", 42), new SqlParameter("bar", "Dirk Gently") };

--- a/PetaPoco/PetaPoco.csproj
+++ b/PetaPoco/PetaPoco.csproj
@@ -20,6 +20,13 @@
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
     <Reference Include="System.Configuration" />
   </ItemGroup>
+ 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net40" Version="1.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
   <ItemGroup>
     <None Update="T4 Templates\Database.tt">


### PR DESCRIPTION
*   Many current dev machines (including mine) don't have net40 reference assemblies installed, and it's no longer possible to obtain them. Including a design-time NuGet package allows things to compile.
*   The PR for DateTime2 updated the signature on `ParametersHelper.ProcessStoredProcParams()` but did not update the corresponding unit test.