### PR TITLE
Fix calls to GetCustomAttributes()

### DIFF
--- a/PetaPoco.Tests.Unit/Core/ConventionMapperTests.cs
+++ b/PetaPoco.Tests.Unit/Core/ConventionMapperTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using PetaPoco.Tests.Unit.Models;
 using Shouldly;
 using Xunit;
 
@@ -269,6 +270,17 @@ namespace PetaPoco.Tests.Unit.Core
             public Guid Id { get; set; }
 
             public int Size { get; set; }
+        }
+
+        [Theory]
+        [InlineData(typeof(Child1))]
+        [InlineData(typeof(Child2))]
+        [InlineData(typeof(Child3))]
+        [InlineData(typeof(Child4))]
+        public void Converters_Should_Inherit(Type type)
+        {
+            var func = _mapper.GetToDbConverter(type.GetProperty("ID"));
+            func.ShouldNotBeNull();
         }
     }
 }

--- a/PetaPoco.Tests.Unit/Core/PocoDataTests.cs
+++ b/PetaPoco.Tests.Unit/Core/PocoDataTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using PetaPoco.Core;
+using PetaPoco.Tests.Unit.Models;
 using Shouldly;
 using Xunit;
 
@@ -52,6 +53,18 @@ namespace PetaPoco.Tests.Unit.Core
 
             [ResultColumn(IncludeInAutoSelect.Yes)]
             public string ResultProperty { get; set; }
+        }
+
+        [Theory]
+        [InlineData(typeof(Child1))]
+        [InlineData(typeof(Child2))]
+        [InlineData(typeof(Child3))]
+        [InlineData(typeof(Child4))]
+        public void Atrributes_Should_Inherit(Type type)
+        {
+            var pd = PocoData.ForType(type, new ConventionMapper());
+            pd.Columns.ShouldContainKey("Foo");
+            pd.Columns.ShouldNotContainKey("Ignored");
         }
     }
 }

--- a/PetaPoco.Tests.Unit/Models/ParentChildClasses.cs
+++ b/PetaPoco.Tests.Unit/Models/ParentChildClasses.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PetaPoco.Tests.Unit.Models
+{
+    public class Parent1
+    {
+        public virtual int ID { get; set; }
+        public virtual string Ignored { get; set; }
+    }
+
+    public class Child1 : Parent1
+    {
+        [Column("Foo")]
+        [FooValueConverter]
+        public override int ID { get; set; }
+        [Ignore]
+        public override string Ignored { get; set; }
+    }
+
+    // -------
+
+    public class Parent2
+    {
+        [Column("Foo")]
+        [FooValueConverter]
+        public virtual int ID { get; set; }
+        [Ignore]
+        public virtual string Ignore { get; set; }
+    }
+
+    public class Child2 : Parent2
+    {
+        public override int ID { get; set; }
+        public override string Ignore { get; set; }
+    }
+
+    // ---------
+
+    public class Parent3
+    {
+        [Column("Foo")]
+        [FooValueConverter]
+        public virtual int ID { get; set; }
+        [Ignore]
+        public virtual string Ignore { get; set; }
+    }
+
+    public class Child3 : Parent3
+    {
+
+    }
+
+    // ---------
+
+    public class Parent4
+    {
+        [Column("NOTFoo")]
+        public virtual int ID { get; set; }
+    }
+
+    public class Child4 : Parent4
+    {
+        [Column("Foo")]
+        [FooValueConverter]
+        public override int ID { get; set; }
+        [Ignore]
+        public virtual string Ignore { get; set; }
+    }
+
+    public class FooValueConverterAttribute : ValueConverterAttribute
+    {
+        public override object ConvertFromDb(object value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override object ConvertToDb(object value)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/PetaPoco.Tests.Unit/Utilities/ParametersHelperTests.cs
+++ b/PetaPoco.Tests.Unit/Utilities/ParametersHelperTests.cs
@@ -1,4 +1,5 @@
 ﻿using Moq;
+using PetaPoco.Core;
 using PetaPoco.Internal;
 using Shouldly;
 using System;
@@ -145,7 +146,7 @@ namespace PetaPoco.Tests.Unit.Utilities
 
         private void NamedProcParamsTestHelper(object[] args_src)
         {
-            Action<IDbDataParameter, object, PropertyInfo> setAction = (p, o, pi) => p.Value = o;
+            Action<IDbDataParameter, object, PocoColumn> setAction = (p, o, pc) => p.Value = o;
             var cmd = new SqlCommand();
 
             var expected = new [] { new SqlParameter("foo", 42), new SqlParameter("bar", "Dirk Gently") };

--- a/PetaPoco/Core/ColumnInfo.cs
+++ b/PetaPoco/Core/ColumnInfo.cs
@@ -65,8 +65,8 @@ namespace PetaPoco
             var isExplicit = pi.DeclaringType.GetCustomAttributes(typeof(ExplicitColumnsAttribute), true).Any();
 
             // Check for [Column]/[Ignore] Attributes
-            columnAttr = pi.GetCustomAttributes(typeof(ColumnAttribute), true).FirstOrDefault() as ColumnAttribute;
-            var isIgnore = pi.GetCustomAttributes(typeof(IgnoreAttribute), true).Any();
+            columnAttr = Attribute.GetCustomAttributes(pi, typeof(ColumnAttribute)).FirstOrDefault() as ColumnAttribute;
+            var isIgnore = Attribute.GetCustomAttributes(pi, typeof(IgnoreAttribute)).Any();
 
             if (isIgnore || (isExplicit && columnAttr == null))
             {

--- a/PetaPoco/Core/ConventionMapper.cs
+++ b/PetaPoco/Core/ConventionMapper.cs
@@ -130,7 +130,7 @@ namespace PetaPoco
             {
                 if (pi != null)
                 {
-                    var valueConverter = pi.GetCustomAttributes(typeof(ValueConverterAttribute), true).FirstOrDefault() as ValueConverterAttribute;
+                    var valueConverter = Attribute.GetCustomAttributes(pi, typeof(ValueConverterAttribute)).FirstOrDefault() as ValueConverterAttribute;
                     if (valueConverter != null)
                         return valueConverter.ConvertFromDb;
                 }
@@ -141,7 +141,7 @@ namespace PetaPoco
             {
                 if (pi != null)
                 {
-                    var valueConverter = pi.GetCustomAttributes(typeof(ValueConverterAttribute), true).FirstOrDefault() as ValueConverterAttribute;
+                    var valueConverter = Attribute.GetCustomAttributes(pi, typeof(ValueConverterAttribute)).FirstOrDefault() as ValueConverterAttribute;
                     if (valueConverter != null)
                         return valueConverter.ConvertToDb;
                 }

--- a/PetaPoco/PetaPoco.csproj
+++ b/PetaPoco/PetaPoco.csproj
@@ -20,6 +20,13 @@
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
     <Reference Include="System.Configuration" />
   </ItemGroup>
+ 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net40" Version="1.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
   <ItemGroup>
     <None Update="T4 Templates\Database.tt">


### PR DESCRIPTION
Fixes #640 

I verified that the tests (specifically Parent2/Child2) failed with the current code and pass after this change.

I wound up using `Attribute.GetCustomAttributes()` because the overload I wanted of `pi.GetCustomAttributes()` doesn't exist in net40.