### PR TITLE
Add Database.CreateParameter()

### DIFF
--- a/PetaPoco.Tests.Unit/CreateParameterTests.cs
+++ b/PetaPoco.Tests.Unit/CreateParameterTests.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace PetaPoco.Tests.Unit
+{
+    public class CreateParameterTests : IDisposable
+    {
+        public readonly DbConnection _conn = new SqlConnection();
+        public readonly Database _db = new Database("foo", "System.Data.SqlClient");
+
+        public void Dispose()
+        {
+            _conn.Dispose();
+            _db.Dispose();
+        }
+
+        private void Validate(IDbDataParameter param, string name, object value, ParameterDirection direction)
+        {
+            param.ShouldSatisfyAllConditions(
+                () => param.ShouldNotBeNull(),
+                () => param.ParameterName.ShouldBe(name),
+                () => param.Value.ShouldBe(value),
+                () => param.Direction.ShouldBe(direction)
+            );
+        }
+
+        [Fact]
+        public void CreateWithNoParams_Should_ReturnDefault()
+        {
+            var output = _db.CreateParameter();
+            Validate(output, String.Empty, null, ParameterDirection.Input);
+        }
+
+        [Fact]
+        public void CreateWithNameAndValue_Should_ReturnInput()
+        {
+            var name = "request_id";
+            var value = 42;
+            var output = _db.CreateParameter(name, value);
+            Validate(output, name, value, ParameterDirection.Input);
+        }
+
+        [Fact]
+        public void CreateWithNameAndDirection_Should_HaveNullValue()
+        {
+            var name = "first_name";
+            var direction = ParameterDirection.Output;
+            var output = _db.CreateParameter(name, direction);
+            Validate(output, name, null, direction);
+        }
+
+        [Fact]
+        public void CreateWithAllParams_Should_ReturnThem()
+        {
+            var name = "ssn";
+            var value = "123-45-6789";
+            var direction = ParameterDirection.InputOutput;
+            var output = _db.CreateParameter(name, value, direction);
+            Validate(output, name, value, direction);
+        }
+    }
+}

--- a/PetaPoco.Tests.Unit/DatabaseConfigurationTests.cs
+++ b/PetaPoco.Tests.Unit/DatabaseConfigurationTests.cs
@@ -282,7 +282,7 @@ namespace PetaPoco.Tests.Unit
             bool eventFired = false;
             EventHandler<DbConnectionEventArgs> handler = (sender, args) => eventFired = true;
 
-            var db = config.UsingConnectionString("cs").UsingProvider<SqlServerDatabaseProvider>().UsingConnectionOpened(handler).Create();
+            var db = config.UsingConnectionString("cs").UsingProvider<SqlServerDatabaseProvider>().UsingConnectionOpening(handler).Create();
 
             (db as Database).OnConnectionOpening(null);
             eventFired.ShouldBeTrue();
@@ -294,7 +294,7 @@ namespace PetaPoco.Tests.Unit
             bool eventFired = false;
             EventHandler<DbConnectionEventArgs> handler = (sender, args) => eventFired = true;
 
-            var db = config.UsingConnectionString("cs").UsingProvider<SqlServerDatabaseProvider>().UsingConnectionOpening(handler).Create();
+            var db = config.UsingConnectionString("cs").UsingProvider<SqlServerDatabaseProvider>().UsingConnectionOpened(handler).Create();
 
             (db as Database).OnConnectionOpened(null);
             eventFired.ShouldBeTrue();

--- a/PetaPoco/Database.cs
+++ b/PetaPoco/Database.cs
@@ -757,6 +757,47 @@ namespace PetaPoco
             return cmd;
         }
 
+        /// <summary>
+        /// Create an IDbDataParameter with default values.
+        /// </summary>
+        /// <returns>The IDbDataParameter</returns>
+        public IDbDataParameter CreateParameter() => _factory.CreateParameter();
+
+        /// <summary>
+        /// Create an IDbDataParameter with the given ParameterName and Value.
+        /// </summary>
+        /// <param name="name">The ParameterName.</param>
+        /// <param name="value">The Value of the parameter.</param>
+        /// <returns></returns>
+        public IDbDataParameter CreateParameter(string name, object value)
+            => CreateParameter(name, value, ParameterDirection.Input);
+
+        /// <summary>
+        /// Create an IDbParameter with the given ParameterName and Direction.
+        /// </summary>
+        /// <param name="name">The ParameterName.</param>
+        /// <param name="direction">The Direction of the parameter.</param>
+        /// <returns></returns>
+        public IDbDataParameter CreateParameter(string name, ParameterDirection direction)
+            => CreateParameter(name, null, direction);
+
+        /// <summary>
+        /// Create an IDbParameter with the given ParameterName, Value, and Direction.
+        /// </summary>
+        /// <param name="name">The ParameterName.</param>
+        /// <param name="value">The Value of the parameter.</param>
+        /// <param name="direction">The Direction of the parameter.</param>
+        /// <returns></returns>
+        public IDbDataParameter CreateParameter(string name, object value, ParameterDirection direction)
+        {
+            var result = CreateParameter();
+            result.ParameterName = name;
+            result.Value = value;
+            result.Direction = direction;
+
+            return result;
+        }
+
 #endregion
 
 #region Exception Reporting and Logging


### PR DESCRIPTION
Better late than never!

Closes #122 

@pleb The existing `CreateCommand()` methods only appear on `Database`, not in any of the implemented interfaces, so I did the same with `CreateParameter()`. 