### PR TITLE
Reinstate virtual-ness of OnExecutedCommand

### DIFF
--- a/PetaPoco/Database.cs
+++ b/PetaPoco/Database.cs
@@ -871,8 +871,10 @@ namespace PetaPoco
         /// </summary>
         /// <param name="cmd">The command to be executed</param>
         /// <remarks>
-        ///     Override this method to provide custom logging of commands and/or
-        ///     modification of the IDbCommand before it's executed
+        ///     Override this method to provide custom logging of commands, 
+        ///     modification of the IDbCommand before it's executed, or any
+        ///     other custom actions that should be performed before every
+        ///     command
         /// </remarks>
         public virtual void OnExecutingCommand(IDbCommand cmd)
         {
@@ -883,7 +885,11 @@ namespace PetaPoco
         ///     Called on completion of command execution
         /// </summary>
         /// <param name="cmd">The IDbCommand that finished executing</param>
-        public void OnExecutedCommand(IDbCommand cmd)
+        /// <remarks>
+        ///     Override this method to provide custom logging or other actions
+        ///     after every command has completed.
+        /// </remarks>
+        public virtual void OnExecutedCommand(IDbCommand cmd)
         {
             CommandExecuted?.Invoke(this, new DbCommandEventArgs(cmd));
         }


### PR DESCRIPTION
The `virtual` keyword was removed in `7de9a0e13a41` "Completes BeginTransactionAsync and PageAsync", as part of PR #507 "Add async support".
I can't see any reason in the surrounding commit to have removed access to this hook-in point, and the other half of the pair (`OnExecutingCommand`) is still virtual.

Perhaps is was simply unintentional? but if intentional then my only guess is that @pleb thought that it wasn't a useful hook point - that "before the command runs" was the useful time to do things :)
I'll respectfully disagree - this pair of hook points allows for an easy place to put things "around" every command, e.g. Perf tracing code and other NFR stuff. I agree that there's very little that you'd want to do to *modify* the cmd object, but having it as essentially an event hook, is still valuable.