### PR TITLE
Fix ReferenceAssemblies dependency

### DIFF
--- a/PetaPoco/PetaPoco.csproj
+++ b/PetaPoco/PetaPoco.csproj
@@ -21,8 +21,8 @@
     <Reference Include="System.Configuration" />
   </ItemGroup>
  
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net40" Version="1.0.2">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -39,8 +39,4 @@
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
   </ItemGroup>
   
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
This appears to be my fault -- when I was doing some work to add a .net standard 2.1 target, it looks like I screwed up the dependency on ReferenceAssemblies. It should only be a build-time dependency, but it was getting linked in to the NuGet package. No harm, just some files dragged in that shouldn't be.