### PR TITLE
Revert license copyright date change from commit 7f4eb8db

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,14 +1,15 @@
-Copyright (C) 2011-2023 Topten Software (contact@toptensoftware.com)
+Copyright (C) 2011-2011 Topten Software (contact@toptensoftware.com)
 All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this product except in compliance with the License.
 You may obtain a copy of the License at
 
-<https://www.apache.org/licenses/LICENSE-2.0>
+<http://www.apache.org/licenses/LICENSE-2.0>
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,15 +1,8 @@
-Copyright (C) 2011-2023  CollaboratingPlatypus/PetaPoco 
-All rights reserved.
+Copyright (C) 2011-2023  
+Copyright 2023 CollaboratingPlatypus/PetaPoco
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this product except in compliance with the License.
-You may obtain a copy of the License at
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-<http://www.apache.org/licenses/LICENSE-2.0>
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (C) 2011-2011 Topten Software (contact@toptensoftware.com)
+Copyright (C) 2011-2023  CollaboratingPlatypus/PetaPoco 
 All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Reverts `LICENSE.txt` to it's former state. See https://github.com/CollaboratingPlatypus/PetaPoco/issues/678#issuecomment-1580604377t from @asherber.