### PR TITLE
675 when inserting name of autoincrement column with expression is not escaped

### DIFF
--- a/PetaPoco/Database.cs
+++ b/PetaPoco/Database.cs
@@ -1960,7 +1960,7 @@ namespace PetaPoco
                     var autoIncExpression = _provider.GetAutoIncrementExpression(pd.TableInfo);
                     if (autoIncExpression != null)
                     {
-                        names.Add(i.Key);
+                        names.Add(_provider.EscapeSqlIdentifier(i.Key));
                         values.Add(autoIncExpression);
                     }
 


### PR DESCRIPTION
As per https://github.com/CollaboratingPlatypus/PetaPoco/issues/675, autoincrement column names should be escaped.