### PR TITLE
bugfix: OpenSharedConnectionAsync fails to invoke OnConnectionOpening

### DIFF
--- a/PetaPoco.Tests.Integration/Databases/BaseDatabaseTests.cs
+++ b/PetaPoco.Tests.Integration/Databases/BaseDatabaseTests.cs
@@ -150,6 +150,8 @@ namespace PetaPoco.Tests.Integration.Databases
             DB.CloseSharedConnection();
         }
 
+        #region Events
+
         [Fact]
         public void OpenSharedConnection_WhenCalled_ShouldInvokeOnConnectionOpening()
         {
@@ -336,5 +338,7 @@ namespace PetaPoco.Tests.Integration.Databases
             await (DB as Database).AbortTransactionAsync();
             eventInvoked.ShouldBeTrue();
         }
+
+        #endregion
     }
 }

--- a/PetaPoco/Database.cs
+++ b/PetaPoco/Database.cs
@@ -380,9 +380,9 @@ namespace PetaPoco
                 _sharedConnection = _factory.CreateConnection();
                 _sharedConnection.ConnectionString = _connectionString;
 
-				_sharedConnection = OnConnectionOpening(_sharedConnection);
+                _sharedConnection = OnConnectionOpening(_sharedConnection);
 
-				if (_sharedConnection.State == ConnectionState.Broken)
+                if (_sharedConnection.State == ConnectionState.Broken)
                     _sharedConnection.Close();
 
                 if (_sharedConnection.State == ConnectionState.Closed)

--- a/PetaPoco/Database.cs
+++ b/PetaPoco/Database.cs
@@ -380,7 +380,9 @@ namespace PetaPoco
                 _sharedConnection = _factory.CreateConnection();
                 _sharedConnection.ConnectionString = _connectionString;
 
-                if (_sharedConnection.State == ConnectionState.Broken)
+				_sharedConnection = OnConnectionOpening(_sharedConnection);
+
+				if (_sharedConnection.State == ConnectionState.Broken)
                     _sharedConnection.Close();
 
                 if (_sharedConnection.State == ConnectionState.Closed)


### PR DESCRIPTION
Added tests for event invocation when opening shared connection with both synchronous and asynchronous methods. `BaseDatabaseTests.OpenSharedConnectionAsync_WhenCalled_ShouldInvokeOnConnectionOpening()` fails on this initial commit. The commit following this fixes `Database.OpenSharedConnectionAsync(CancellationToken)` to call `OnConnectionOpening` as the synchronous counterpart does, and results in a passing test.

I'll add tests for the remaining events shortly for completeness' sake.

closes #685 