### PR TITLE
Fix NullReferenceException thrown when executing operations with `dynamic` POCOs

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,8 +1,13 @@
-Copyright (C) 2011-2023  
 Copyright 2023 CollaboratingPlatypus/PetaPoco
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/PetaPoco.Tests.Integration/Databases/BaseUpdateTests.cs
+++ b/PetaPoco.Tests.Integration/Databases/BaseUpdateTests.cs
@@ -291,23 +291,60 @@ namespace PetaPoco.Tests.Integration.Databases
         }
 
         [Fact]
-        [Trait("Issue", "667")]
-        public void Update_GivenDynamicPoco_ShouldNotThrow() {
-            DB.Insert(_note);
-			var entity = DB.First<dynamic>("SELECT * FROM Note");
-			Should.NotThrow(() => DB.Update("Note", "Id", entity));
+        public void Update_GivenTablePrimaryKeyNameAndDynamicType_ShouldBeValid()
+        {
+            DB.Insert(_person);
+
+            dynamic person = new System.Dynamic.ExpandoObject();
+            person.Id = _person.Id;
+            person.FullName = "Feta";
+            person.Age = 19;
+            person.Dob = new DateTime(1946, 1, 12, 5, 9, 4, DateTimeKind.Utc);
+            person.Height = 190;
+
+            ((int)DB.Update("People", "Id", person)).ShouldBe(1);
+
+            var personOther = DB.Single<Person>(_person.Id);
+            personOther.ShouldNotBe(_person, true);
         }
 
         [Fact]
-        public void Update_GivenDynamicPoco_ShouldUpdate() {
+        public void Update_GivenTablePrimaryKeyNameDynamicTypeAndPrimaryKeyValue_ShouldBeValid()
+        {
+            DB.Insert(_person);
+
+            dynamic person = new System.Dynamic.ExpandoObject();
+            person.FullName = "Feta";
+            person.Age = 19;
+            person.Dob = new DateTime(1946, 1, 12, 5, 9, 4, DateTimeKind.Utc);
+            person.Height = 190;
+
+            ((int)DB.Update("People", "Id", person, _person.Id)).ShouldBe(1);
+
+            var personOther = DB.Single<Person>(_person.Id);
+            personOther.ShouldNotBe(_person, true);
+        }
+
+        [Fact]
+        [Trait("Issue", "667")]
+        public void Update_GivenDynamicPoco_ShouldNotThrow()
+        {
             DB.Insert(_note);
-			var entity = DB.First<dynamic>("SELECT * FROM Note");
+            var entity = DB.Fetch<dynamic>("SELECT * FROM Note").First();
+            Should.NotThrow(() => DB.Update("Note", "Id", entity));
+        }
 
-			entity.Text += " was updated";
-			DB.Update("Note", "Id", entity);
+        [Fact]
+        public void Update_GivenDynamicPoco_ShouldUpdate()
+        {
+            DB.Insert(_note);
+            var entity = DB.Fetch<dynamic>("SELECT * FROM Note").First();
 
-			var entity2 = DB.First<dynamic>("SELECT * FROM Note");
-			((string)entity2.Text).ShouldContain("updated");
+            entity.Text += " was updated";
+            DB.Update("Note", "Id", entity);
+
+            var entity2 = DB.Fetch<dynamic>("SELECT * FROM Note").First();
+            ((string)entity2.Text).ShouldContain("updated");
         }
 
         [Fact]
@@ -552,6 +589,63 @@ namespace PetaPoco.Tests.Integration.Databases
             var personOther = await DB.SingleAsync<Person>(_person.Id);
 
             personOther.ShouldNotBe(_person, true);
+        }
+
+        [Fact]
+        public async Task UpdateAsync_GivenTablePrimaryKeyNameAndDynamicType_ShouldBeValid()
+        {
+            await DB.InsertAsync(_person);
+
+            dynamic person = new System.Dynamic.ExpandoObject();
+            person.Id = _person.Id;
+            person.FullName = "Feta";
+            person.Age = 19;
+            person.Dob = new DateTime(1946, 1, 12, 5, 9, 4, DateTimeKind.Utc);
+            person.Height = 190;
+
+            ((int)await DB.UpdateAsync("People", "Id", person)).ShouldBe(1);
+
+            var personOther = await DB.SingleAsync<Person>(_person.Id);
+            personOther.ShouldNotBe(_person, true);
+        }
+
+        [Fact]
+        public async Task UpdateAsync_GivenTablePrimaryKeyNameDynamicTypeAndPrimaryKeyValue_ShouldBeValid()
+        {
+            await DB.InsertAsync(_person);
+
+            dynamic person = new System.Dynamic.ExpandoObject();
+            person.FullName = "Feta";
+            person.Age = 19;
+            person.Dob = new DateTime(1946, 1, 12, 5, 9, 4, DateTimeKind.Utc);
+            person.Height = 190;
+
+            ((int)await DB.UpdateAsync("People", "Id", person, _person.Id)).ShouldBe(1);
+
+            var personOther = await DB.SingleAsync<Person>(_person.Id);
+            personOther.ShouldNotBe(_person, true);
+        }
+
+        [Fact]
+        [Trait("Issue", "667")]
+        public async Task UpdateAsync_GivenDynamicPoco_ShouldNotThrow()
+        {
+            await DB.InsertAsync(_note);
+            var entity = (await DB.FetchAsync<dynamic>("SELECT * FROM Note")).First();
+            Should.NotThrow(() => DB.Update("Note", "Id", entity));
+        }
+
+        [Fact]
+        public async Task UpdateAsync_GivenDynamicPoco_ShouldUpdate()
+        {
+            await DB.InsertAsync(_note);
+            var entity = (await DB.FetchAsync<dynamic>("SELECT * FROM Note")).First();
+
+            entity.Text += " was updated";
+            DB.Update("Note", "Id", entity);
+
+            var entity2 = (await DB.FetchAsync<dynamic>("SELECT * FROM Note")).First();
+            ((string)entity2.Text).ShouldContain("updated");
         }
 
         private Person SinglePersonOther(Guid id)

--- a/PetaPoco.Tests.Integration/Databases/BaseUpdateTests.cs
+++ b/PetaPoco.Tests.Integration/Databases/BaseUpdateTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
 using PetaPoco.Core;
@@ -32,6 +32,12 @@ namespace PetaPoco.Tests.Integration.Databases
             Dob = new DateTime(1945, 1, 12, 5, 9, 4, DateTimeKind.Utc),
             Height = 180,
             Name = "Peta"
+        };
+
+        private Note _note = new Note
+        {
+            CreatedOn = new DateTime(1948, 1, 11, 4, 2, 4, DateTimeKind.Utc),
+            Text = "Peta's Note",
         };
 
         protected BaseUpdateTests(DBTestProvider provider)
@@ -282,6 +288,14 @@ namespace PetaPoco.Tests.Integration.Databases
             var personOther = DB.Single<Person>(_person.Id);
 
             personOther.ShouldNotBe(_person, true);
+        }
+
+        [Fact]
+        [Trait("Issue", "667")]
+        public void Update_GivenDynamicPoco_ShouldNotThrow() {
+            DB.Insert(_note);
+            var entity = DB.Fetch<dynamic>("SELECT * FROM Note").First();
+            Should.NotThrow(() => DB.Update("Note", "Id", entity));
         }
 
         [Fact]

--- a/PetaPoco.Tests.Integration/Databases/BaseUpdateTests.cs
+++ b/PetaPoco.Tests.Integration/Databases/BaseUpdateTests.cs
@@ -294,8 +294,20 @@ namespace PetaPoco.Tests.Integration.Databases
         [Trait("Issue", "667")]
         public void Update_GivenDynamicPoco_ShouldNotThrow() {
             DB.Insert(_note);
-            var entity = DB.Fetch<dynamic>("SELECT * FROM Note").First();
-            Should.NotThrow(() => DB.Update("Note", "Id", entity));
+			var entity = DB.First<dynamic>("SELECT * FROM Note");
+			Should.NotThrow(() => DB.Update("Note", "Id", entity));
+        }
+
+        [Fact]
+        public void Update_GivenDynamicPoco_ShouldUpdate() {
+            DB.Insert(_note);
+			var entity = DB.First<dynamic>("SELECT * FROM Note");
+
+			entity.Text += " was updated";
+			DB.Update("Note", "Id", entity);
+
+			var entity2 = DB.First<dynamic>("SELECT * FROM Note");
+			((string)entity2.Text).ShouldContain("updated");
         }
 
         [Fact]

--- a/PetaPoco/Database.cs
+++ b/PetaPoco/Database.cs
@@ -597,7 +597,7 @@ namespace PetaPoco
         private void AddParam(IDbCommand cmd, object value, PocoColumn pc)
         {
             // Convert value to from poco type to db type
-            if (pc != null && pc.PropertyInfo != null)
+            if (pc?.PropertyInfo != null)
             {
                 var mapper = Mappers.GetMapper(pc.PropertyInfo.DeclaringType, _defaultMapper);
                 var fn = mapper.GetToDbConverter(pc.PropertyInfo);
@@ -2253,13 +2253,14 @@ namespace PetaPoco
             }
 
             // Find the property info for the primary key
-            //PropertyInfo pkpi = null;
             PocoColumn col = null;
             if (primaryKeyName != null)
             {
-                //PocoColumn col;
-                //pkpi = pd.Columns.TryGetValue(primaryKeyName, out col) ? col.PropertyInfo : new { Id = primaryKeyValue }.GetType().GetProperties()[0];
-                pd.Columns.TryGetValue(primaryKeyName, out col);
+                if (!pd.Columns.TryGetValue(primaryKeyName, out col))
+                {
+                    var pkpi = new { Id = primaryKeyValue }.GetType().GetProperty("Id");
+                    col = new PocoColumn() { PropertyInfo = pkpi };
+                }
             }
 
             cmd.CommandText =

--- a/PetaPoco/Database.cs
+++ b/PetaPoco/Database.cs
@@ -597,7 +597,7 @@ namespace PetaPoco
         private void AddParam(IDbCommand cmd, object value, PocoColumn pc)
         {
             // Convert value to from poco type to db type
-            if (pc != null)
+            if (pc != null && pc.PropertyInfo != null)
             {
                 var mapper = Mappers.GetMapper(pc.PropertyInfo.DeclaringType, _defaultMapper);
                 var fn = mapper.GetToDbConverter(pc.PropertyInfo);
@@ -2122,7 +2122,7 @@ namespace PetaPoco
 
         /// <inheritdoc />
         public int Update(string tableName, string primaryKeyName, object poco)
-            => Update(tableName, primaryKeyName, poco, null);
+            => Update(tableName, primaryKeyName, poco, null, null);
 
         /// <inheritdoc />
         public int Update(string tableName, string primaryKeyName, object poco, IEnumerable<string> columns)


### PR DESCRIPTION
The exception occurs when passing in the PocoColumn to the `AddParam` method. As I mentioned in the linked issue thread, this is fine for statically typed POCO objects, but for dynamic or anonymous types, there is no underlying compile-time PropertyInfo for that column (property).

Changing the null check from `if (pc != null)` to `if (pc != null && pc.PropertyInfo != null)` fixes the problem, but I'm not convinced this is the ideal resolution, since the method is specifically designed to accept a null value for the third parameter (for dynamic and anonymous types), and likely there are other bugs related to dynamic that would share the same root cause as this one, somewhere farther down the call path.

https://github.com/CollaboratingPlatypus/PetaPoco/blob/34ff2900ec72d5cae863d4b04f7d87bcc4d15394/PetaPoco/Database.cs#L594-L600

Looking at how anonymous types (which are unaffected, but most likely follow the same call path) are treated internally:

https://github.com/CollaboratingPlatypus/PetaPoco/blob/34ff2900ec72d5cae863d4b04f7d87bcc4d15394/PetaPoco/Database.cs#L756-L757

So the question then is, do we need to be treating dynamic types differently (like anonymous types), or just handle the edge cases with more robust null checks to influence the execution path at runtime? Personally, I've only ever used statically typed objects with PetaPoco, so my knowledge of how runtime types are handled internally is rather limited. Any feedback from @pleb or @asherber would be helpful.

Fixes #667 