### PR TITLE
Fix issues with dynamic introduced in 32ea9ca

### DIFF
--- a/PetaPoco/Database.cs
+++ b/PetaPoco/Database.cs
@@ -599,7 +599,7 @@ namespace PetaPoco
         private void AddParam(IDbCommand cmd, object value, PocoColumn pc)
         {
             // Convert value to from poco type to db type
-            if (pc != null)
+            if (pc?.PropertyInfo != null)
             {
                 var mapper = Mappers.GetMapper(pc.PropertyInfo.DeclaringType, _defaultMapper);
                 var fn = mapper.GetToDbConverter(pc.PropertyInfo);
@@ -2255,13 +2255,14 @@ namespace PetaPoco
             }
 
             // Find the property info for the primary key
-            //PropertyInfo pkpi = null;
             PocoColumn col = null;
             if (primaryKeyName != null)
             {
-                //PocoColumn col;
-                //pkpi = pd.Columns.TryGetValue(primaryKeyName, out col) ? col.PropertyInfo : new { Id = primaryKeyValue }.GetType().GetProperties()[0];
-                pd.Columns.TryGetValue(primaryKeyName, out col);
+                if (!pd.Columns.TryGetValue(primaryKeyName, out col))
+                {
+                    var pkpi = new { Id = primaryKeyValue }.GetType().GetProperty("Id");
+                    col = new PocoColumn() { PropertyInfo = pkpi };
+                }
             }
 
             cmd.CommandText =


### PR DESCRIPTION
I'd like to suggest this as an alternative to #687. It should fix the issues originally introduced in 32ea9ca by:

1. Restoring in the null check suggested by @Ste1io.
2. Restoring [this code](https://github.com/CollaboratingPlatypus/PetaPoco/blob/29afd6f591934b5a5e9e2c69bb2d9f923cd42577/PetaPoco/Database.cs#L2187) for getting property info for the primary key during an update when there is no `PocoColumn` available in `PocoData`. The deletion of this code was a hidden bug that may also have come into play with #667 