### PR TITLE
Fix remaining failing integration tests

### DIFF
--- a/PetaPoco.Tests.Integration/Databases/OracleTests/OracleDatabaseTests.cs
+++ b/PetaPoco.Tests.Integration/Databases/OracleTests/OracleDatabaseTests.cs
@@ -1,14 +1,50 @@
-﻿using PetaPoco.Tests.Integration.Providers;
+﻿using System.Reflection;
+using PetaPoco.Tests.Integration.Providers;
 using Xunit;
 
 namespace PetaPoco.Tests.Integration.Databases.Oracle
 {
-    [Collection("Oracle")]
-    public class OracleDatabaseTests : DatabaseTests
+    public abstract partial class OracleDatabaseTests : DatabaseTests
     {
-        public OracleDatabaseTests()
-            : base(new OracleTestProvider())
+        private OracleTestProvider _provider;
+
+        protected OracleDatabaseTests(OracleTestProvider provider)
+            : base(provider)
         {
+            _provider = provider;
+        }
+
+        [Collection("Oracle.Delimited")]
+        public class Delimited : OracleDatabaseTests
+        {
+            public Delimited()
+                : base(new OracleDelimitedTestProvider())
+            {
+            }
+        }
+
+        [Collection("Oracle.Ordinary")]
+        public class Ordinary : OracleDatabaseTests
+        {
+            public Ordinary()
+                : base(new OracleOrdinaryTestProvider())
+            {
+            }
+
+            /// <remarks>
+            /// We need to retain the provider and mapper specified in the test provider
+            /// to ensure correct logic is applied, because they might be custom implementations.
+            /// </remarks>
+            protected override void AfterDbCreate(Database db)
+            {
+                var thisDb = _provider.GetDatabase();
+                base.AfterDbCreate(db);
+
+                // ReSharper disable once PossibleNullReferenceException
+                db.GetType().GetField("_provider", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(db, thisDb.Provider);
+                // ReSharper disable once PossibleNullReferenceException
+                db.GetType().GetField("_defaultMapper", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(db, thisDb.DefaultMapper);
+            }
         }
     }
 }

--- a/PetaPoco.Tests.Integration/Databases/OracleTests/OracleDeleteTests.cs
+++ b/PetaPoco.Tests.Integration/Databases/OracleTests/OracleDeleteTests.cs
@@ -3,12 +3,29 @@ using Xunit;
 
 namespace PetaPoco.Tests.Integration.Databases.Oracle
 {
-    [Collection("Oracle")]
-    public class OracleDeleteTests : DeleteTests
+    public abstract partial class OracleDeleteTests : DeleteTests
     {
-        public OracleDeleteTests()
-            : base(new OracleTestProvider())
+        protected OracleDeleteTests(TestProvider provider)
+            : base(provider)
         {
+        }
+
+        [Collection("Oracle.Delimited")]
+        public class Delimited : OracleDeleteTests
+        {
+            public Delimited()
+                : base(new OracleDelimitedTestProvider())
+            {
+            }
+        }
+
+        [Collection("Oracle.Ordinary")]
+        public class Ordinary : OracleDeleteTests
+        {
+            public Ordinary()
+                : base(new OracleOrdinaryTestProvider())
+            {
+            }
         }
     }
 }

--- a/PetaPoco.Tests.Integration/Databases/OracleTests/OracleExecuteTests.cs
+++ b/PetaPoco.Tests.Integration/Databases/OracleTests/OracleExecuteTests.cs
@@ -3,12 +3,29 @@ using Xunit;
 
 namespace PetaPoco.Tests.Integration.Databases.Oracle
 {
-    [Collection("Oracle")]
-    public class OracleExecuteTests : ExecuteTests
+    public abstract partial class OracleExecuteTests : ExecuteTests
     {
-        public OracleExecuteTests()
-            : base(new OracleTestProvider())
+        protected OracleExecuteTests(TestProvider provider)
+            : base(provider)
         {
+        }
+
+        [Collection("Oracle.Delimited")]
+        public class Delimited : OracleExecuteTests
+        {
+            public Delimited()
+                : base(new OracleDelimitedTestProvider())
+            {
+            }
+        }
+
+        [Collection("Oracle.Ordinary")]
+        public class Ordinary : OracleExecuteTests
+        {
+            public Ordinary()
+                : base(new OracleOrdinaryTestProvider())
+            {
+            }
         }
     }
 }

--- a/PetaPoco.Tests.Integration/Databases/OracleTests/OracleInsertTests.cs
+++ b/PetaPoco.Tests.Integration/Databases/OracleTests/OracleInsertTests.cs
@@ -5,12 +5,29 @@ using Xunit;
 
 namespace PetaPoco.Tests.Integration.Databases.Oracle
 {
-    [Collection("Oracle")]
-    public class OracleInsertTests : InsertTests
+    public abstract partial class OracleInsertTests : InsertTests
     {
-        public OracleInsertTests()
-            : base(new OracleTestProvider())
+        protected OracleInsertTests(TestProvider provider)
+            : base(provider)
         {
+        }
+
+        [Collection("Oracle.Delimited")]
+        public class Delimited : OracleInsertTests
+        {
+            public Delimited()
+                : base(new OracleDelimitedTestProvider())
+            {
+            }
+        }
+
+        [Collection("Oracle.Ordinary")]
+        public class Ordinary : OracleInsertTests
+        {
+            public Ordinary()
+                : base(new OracleOrdinaryTestProvider())
+            {
+            }
         }
     }
 }

--- a/PetaPoco.Tests.Integration/Databases/OracleTests/OracleMiscellaneousTests.cs
+++ b/PetaPoco.Tests.Integration/Databases/OracleTests/OracleMiscellaneousTests.cs
@@ -3,12 +3,29 @@ using Xunit;
 
 namespace PetaPoco.Tests.Integration.Databases.Oracle
 {
-    [Collection("Oracle")]
-    public class OracleMiscellaneousTests : MiscellaneousTests
+    public abstract partial class OracleMiscellaneousTests : MiscellaneousTests
     {
-        public OracleMiscellaneousTests()
-            : base(new OracleTestProvider())
+        protected OracleMiscellaneousTests(TestProvider provider)
+            : base(provider)
         {
+        }
+
+        [Collection("Oracle.Delimited")]
+        public class Delimited : OracleMiscellaneousTests
+        {
+            public Delimited()
+                : base(new OracleDelimitedTestProvider())
+            {
+            }
+        }
+
+        [Collection("Oracle.Ordinary")]
+        public class Ordinary : OracleMiscellaneousTests
+        {
+            public Ordinary()
+                : base(new OracleOrdinaryTestProvider())
+            {
+            }
         }
     }
 }

--- a/PetaPoco.Tests.Integration/Databases/OracleTests/OraclePreExecuteTests.cs
+++ b/PetaPoco.Tests.Integration/Databases/OracleTests/OraclePreExecuteTests.cs
@@ -6,36 +6,79 @@ using Xunit;
 
 namespace PetaPoco.Tests.Integration.Databases.Oracle
 {
-    [Collection("Oracle")]
-    public class OraclePreExecuteTests : PreExecuteTests
+    public abstract partial class OraclePreExecuteTests : PreExecuteTests
     {
-        protected override IPreExecuteDatabaseProvider Provider => DB.Provider as PreExecuteDatabaseProvider;
-
-        public OraclePreExecuteTests()
-            : base(new PreExecuteTestProvider())
+        protected OraclePreExecuteTests(TestProvider provider)
+            : base(provider)
         {
-            Provider.ThrowExceptions = true;
         }
 
-        protected class PreExecuteTestProvider : OracleTestProvider
+        [Collection("Oracle.Delimited")]
+        public class Delimited : OraclePreExecuteTests
         {
-            protected override IDatabase LoadFromConnectionName(string name)
-                => BuildFromConnectionName(name).UsingProvider<PreExecuteDatabaseProvider>().Create();
-        }
+            protected override IPreExecuteDatabaseProvider Provider => DB.Provider as PreExecuteDatabaseProvider;
 
-        protected class PreExecuteDatabaseProvider : PetaPoco.Providers.OracleDatabaseProvider, IPreExecuteDatabaseProvider
-        {
-            public bool ThrowExceptions { get; set; }
-            public List<IDataParameter> Parameters { get; set; } = new List<IDataParameter>();
-
-            public override void PreExecute(IDbCommand cmd)
+            public Delimited()
+                : base(new PreExecuteTestProvider())
             {
-                Parameters.Clear();
+                Provider.ThrowExceptions = true;
+            }
 
-                if (ThrowExceptions)
+            protected class PreExecuteTestProvider : OracleDelimitedTestProvider
+            {
+                protected override IDatabase LoadFromConnectionName(string name)
+                    => BuildFromConnectionName(name).UsingProvider<PreExecuteDatabaseProvider>().Create();
+            }
+
+            protected class PreExecuteDatabaseProvider : PetaPoco.Providers.OracleDatabaseProvider, IPreExecuteDatabaseProvider
+            {
+                public bool ThrowExceptions { get; set; }
+                public List<IDataParameter> Parameters { get; set; } = new List<IDataParameter>();
+
+                public override void PreExecute(IDbCommand cmd)
                 {
-                    Parameters = cmd.Parameters.Cast<IDataParameter>().ToList();
-                    throw new PreExecuteException();
+                    Parameters.Clear();
+
+                    if (ThrowExceptions)
+                    {
+                        Parameters = cmd.Parameters.Cast<IDataParameter>().ToList();
+                        throw new PreExecuteException();
+                    }
+                }
+            }
+        }
+
+        [Collection("Oracle.Ordinary")]
+        public class Ordinary : OraclePreExecuteTests
+        {
+            protected override IPreExecuteDatabaseProvider Provider => DB.Provider as PreExecuteDatabaseProvider;
+
+            public Ordinary()
+                : base(new PreExecuteTestProvider())
+            {
+                Provider.ThrowExceptions = true;
+            }
+
+            protected class PreExecuteTestProvider : OracleOrdinaryTestProvider
+            {
+                protected override IDatabase LoadFromConnectionName(string name)
+                    => BuildFromConnectionName(name).UsingProvider<PreExecuteDatabaseProvider>().Create();
+            }
+
+            protected class PreExecuteDatabaseProvider : PetaPoco.Providers.OracleDatabaseProvider, IPreExecuteDatabaseProvider
+            {
+                public bool ThrowExceptions { get; set; }
+                public List<IDataParameter> Parameters { get; set; } = new List<IDataParameter>();
+
+                public override void PreExecute(IDbCommand cmd)
+                {
+                    Parameters.Clear();
+
+                    if (ThrowExceptions)
+                    {
+                        Parameters = cmd.Parameters.Cast<IDataParameter>().ToList();
+                        throw new PreExecuteException();
+                    }
                 }
             }
         }

--- a/PetaPoco.Tests.Integration/Databases/OracleTests/OracleQueryLinqTests.cs
+++ b/PetaPoco.Tests.Integration/Databases/OracleTests/OracleQueryLinqTests.cs
@@ -3,12 +3,29 @@ using Xunit;
 
 namespace PetaPoco.Tests.Integration.Databases.Oracle
 {
-    [Collection("Oracle")]
-    public class OracleQueryLinqTests : QueryLinqTests
+    public abstract partial class OracleQueryLinqTests : QueryLinqTests
     {
-        public OracleQueryLinqTests()
-            : base(new OracleTestProvider())
+        protected OracleQueryLinqTests(TestProvider provider)
+            : base(provider)
         {
+        }
+
+        [Collection("Oracle.Delimited")]
+        public class Delimited : OracleQueryLinqTests
+        {
+            public Delimited()
+                : base(new OracleDelimitedTestProvider())
+            {
+            }
+        }
+
+        [Collection("Oracle.Ordinary")]
+        public class Ordinary : OracleQueryLinqTests
+        {
+            public Ordinary()
+                : base(new OracleOrdinaryTestProvider())
+            {
+            }
         }
     }
 }

--- a/PetaPoco.Tests.Integration/Databases/OracleTests/OracleTriageTests.cs
+++ b/PetaPoco.Tests.Integration/Databases/OracleTests/OracleTriageTests.cs
@@ -3,12 +3,29 @@ using Xunit;
 
 namespace PetaPoco.Tests.Integration.Databases.Oracle
 {
-    [Collection("Oracle")]
-    public class OracleTriageTests : TriageTests
+    public abstract partial class OracleTriageTests : TriageTests
     {
-        public OracleTriageTests()
-            : base(new OracleTestProvider())
+        protected OracleTriageTests(TestProvider provider)
+            : base(provider)
         {
+        }
+
+        [Collection("Oracle.Delimited")]
+        public class Delimited : OracleTriageTests
+        {
+            public Delimited()
+                : base(new OracleDelimitedTestProvider())
+            {
+            }
+        }
+
+        [Collection("Oracle.Ordinary")]
+        public class Ordinary : OracleTriageTests
+        {
+            public Ordinary()
+                : base(new OracleOrdinaryTestProvider())
+            {
+            }
         }
     }
 }

--- a/PetaPoco.Tests.Integration/Databases/OracleTests/OracleUpdateTests.cs
+++ b/PetaPoco.Tests.Integration/Databases/OracleTests/OracleUpdateTests.cs
@@ -1,14 +1,114 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using PetaPoco.Core;
+using PetaPoco.Tests.Integration.Models;
 using PetaPoco.Tests.Integration.Providers;
+using Shouldly;
 using Xunit;
 
 namespace PetaPoco.Tests.Integration.Databases.Oracle
 {
-    [Collection("Oracle")]
-    public class OracleUpdateTests : UpdateTests
+    public abstract partial class OracleUpdateTests : UpdateTests
     {
-        public OracleUpdateTests()
-            : base(new OracleTestProvider())
+        protected OracleUpdateTests(TestProvider provider)
+            : base(provider)
         {
+        }
+
+        [Collection("Oracle.Delimited")]
+        public class Delimited : OracleUpdateTests
+        {
+            public Delimited()
+                : base(new OracleDelimitedTestProvider())
+            {
+            }
+        }
+
+        [Collection("Oracle.Ordinary")]
+        public class Ordinary : OracleUpdateTests
+        {
+            public Ordinary()
+                : base(new OracleOrdinaryTestProvider())
+            {
+            }
+
+            [Fact]
+            [Trait("Issue", "#667")]
+            public override void Update_GivenTablePrimaryKeyNameAndDynamicType_ShouldNotThrow()
+            {
+                var pd = PocoData.ForType(typeof(Note), DB.DefaultMapper);
+                var tblNote = DB.Provider.EscapeTableName(pd.TableInfo.TableName);
+
+                DB.Insert(note);
+                var entity = DB.Fetch<dynamic>($"SELECT * FROM {tblNote}").First();
+
+#if !NETCOREAPP
+                Should.NotThrow(() => DB.Update("NOTE", "ID", (object)entity));
+#else
+                Should.NotThrow(() => DB.Update("NOTE", "ID", entity));
+#endif
+            }
+
+            [Fact]
+            public override void Update_GivenTablePrimaryKeyNameAndDynamicType_ShouldUpdate()
+            {
+                var pd = PocoData.ForType(typeof(Note), DB.DefaultMapper);
+                var tblNote = DB.Provider.EscapeTableName(pd.TableInfo.TableName);
+
+                DB.Insert(note);
+                var entity = DB.Fetch<dynamic>($"SELECT * FROM {tblNote}").First();
+
+                entity.TEXT += " was updated";
+
+#if !NETCOREAPP
+                DB.Update("NOTE", "ID", (object)entity);
+#else
+                DB.Update("NOTE", "ID", entity);
+#endif
+
+                var entity2 = DB.Fetch<dynamic>($"SELECT * FROM {tblNote}").First();
+                ((string)entity2.TEXT).ShouldContain("updated");
+            }
+
+            [Fact]
+            [Trait("Issue", "#667")]
+            public override async Task UpdateAsync_GivenTablePrimaryKeyNameAndDynamicType_ShouldNotThrow()
+            {
+                var pd = PocoData.ForType(typeof(Note), DB.DefaultMapper);
+                var tblNote = DB.Provider.EscapeTableName(pd.TableInfo.TableName);
+
+                await DB.InsertAsync(note);
+                var entity = (await DB.FetchAsync<dynamic>($"SELECT * FROM {tblNote}")).First();
+
+                // https://docs.shouldly.org/documentation/exceptions/throw#shouldthrowfuncoftask
+#if !NETCOREAPP
+                Should.NotThrow(async () => await Task.Run(() => DB.UpdateAsync("NOTE", "ID", (object)entity)));
+#else
+                await Should.NotThrowAsync(() => DB.UpdateAsync("NOTE", "ID", entity));
+#endif
+            }
+
+            [Fact]
+            public override async Task UpdateAsync_GivenTablePrimaryKeyNameAndDynamicType_ShouldUpdate()
+            {
+                var pd = PocoData.ForType(typeof(Note), DB.DefaultMapper);
+                var tblNote = DB.Provider.EscapeTableName(pd.TableInfo.TableName);
+
+                await DB.InsertAsync(note);
+                var entity = (await DB.FetchAsync<dynamic>($"SELECT * FROM {tblNote}")).First();
+
+                entity.TEXT += " was updated";
+
+#if !NETCOREAPP
+                await DB.UpdateAsync("NOTE", "ID", (object)entity);
+#else
+                await DB.UpdateAsync("NOTE", "ID", entity);
+#endif
+
+                var entity2 = (await DB.FetchAsync<dynamic>($"SELECT * FROM {tblNote}")).First();
+                ((string)entity2.TEXT).ShouldContain("updated");
+            }
         }
     }
 }

--- a/PetaPoco.Tests.Integration/Databases/UpdateTests.cs
+++ b/PetaPoco.Tests.Integration/Databases/UpdateTests.cs
@@ -37,7 +37,7 @@ namespace PetaPoco.Tests.Integration
             Name = "Peta"
         };
 
-        private Note _note = new Note
+        protected Note note = new Note
         {
             CreatedOn = new DateTime(1948, 1, 11, 4, 2, 4, DateTimeKind.Utc),
             Text = "Peta's Note",
@@ -80,7 +80,6 @@ namespace PetaPoco.Tests.Integration
             orderLine.SellPrice = 5.99m;
             orderLine.Status = OrderLineStatus.Allocated;
         }
-
         #endregion
 
         [Fact]
@@ -376,7 +375,7 @@ namespace PetaPoco.Tests.Integration
             var pd = PocoData.ForType(typeof(Note), DB.DefaultMapper);
             var tblNote = DB.Provider.EscapeTableName(pd.TableInfo.TableName);
 
-            DB.Insert(_note);
+            DB.Insert(note);
             var entity = DB.Fetch<dynamic>($"SELECT * FROM {tblNote}").First();
 
 #if !NETCOREAPP
@@ -392,7 +391,7 @@ namespace PetaPoco.Tests.Integration
             var pd = PocoData.ForType(typeof(Note), DB.DefaultMapper);
             var tblNote = DB.Provider.EscapeTableName(pd.TableInfo.TableName);
 
-            DB.Insert(_note);
+            DB.Insert(note);
             var entity = DB.Fetch<dynamic>($"SELECT * FROM {tblNote}").First();
 
             entity.Text += " was updated";
@@ -694,12 +693,12 @@ namespace PetaPoco.Tests.Integration
 
         [Fact]
         [Trait("Issue", "#667")]
-        public async Task UpdateAsync_GivenTablePrimaryKeyNameAndDynamicType_ShouldNotThrow()
+        public virtual async Task UpdateAsync_GivenTablePrimaryKeyNameAndDynamicType_ShouldNotThrow()
         {
             var pd = PocoData.ForType(typeof(Note), DB.DefaultMapper);
             var tblNote = DB.Provider.EscapeTableName(pd.TableInfo.TableName);
 
-            await DB.InsertAsync(_note);
+            await DB.InsertAsync(note);
             var entity = (await DB.FetchAsync<dynamic>($"SELECT * FROM {tblNote}")).First();
 
             // https://docs.shouldly.org/documentation/exceptions/throw#shouldthrowfuncoftask
@@ -711,12 +710,12 @@ namespace PetaPoco.Tests.Integration
         }
 
         [Fact]
-        public async Task UpdateAsync_GivenTablePrimaryKeyNameAndDynamicType_ShouldUpdate()
+        public virtual async Task UpdateAsync_GivenTablePrimaryKeyNameAndDynamicType_ShouldUpdate()
         {
             var pd = PocoData.ForType(typeof(Note), DB.DefaultMapper);
             var tblNote = DB.Provider.EscapeTableName(pd.TableInfo.TableName);
 
-            await DB.InsertAsync(_note);
+            await DB.InsertAsync(note);
             var entity = (await DB.FetchAsync<dynamic>($"SELECT * FROM {tblNote}")).First();
 
             entity.Text += " was updated";

--- a/PetaPoco.Tests.Integration/PetaPoco.Tests.Integration.csproj
+++ b/PetaPoco.Tests.Integration/PetaPoco.Tests.Integration.csproj
@@ -22,8 +22,10 @@
     <None Remove="Scripts\MariaDBBuildDatabase.sql" />
     <None Remove="Scripts\MSAccessBuildDatabase.sql" />
     <None Remove="Scripts\MySqlBuildDatabase.sql" />
-    <None Remove="Scripts\OracleBuildDatabase.sql" />
-    <None Remove="Scripts\OracleSetupDatabase.sql" />
+    <None Remove="Scripts\OracleBuildDatabaseDelimited.sql" />
+    <None Remove="Scripts\OracleBuildDatabaseOrdinary.sql" />
+    <None Remove="Scripts\OracleSetupDatabaseDelimited.sql" />
+    <None Remove="Scripts\OracleSetupDatabaseOrdinary.sql" />
     <None Remove="Scripts\PostgresBuildDatabase.sql" />
     <None Remove="Scripts\SQLiteBuildDatabase.sql" />
     <None Remove="Scripts\SqlServerBuildDatabase.sql" />
@@ -35,8 +37,10 @@
     <EmbeddedResource Include="Scripts\MariaDBBuildDatabase.sql" />
     <EmbeddedResource Include="Scripts\MSAccessBuildDatabase.sql" />
     <EmbeddedResource Include="Scripts\MySqlBuildDatabase.sql" />
-    <EmbeddedResource Include="Scripts\OracleBuildDatabase.sql" />
-    <EmbeddedResource Include="Scripts\OracleSetupDatabase.sql" />
+    <EmbeddedResource Include="Scripts\OracleBuildDatabaseDelimited.sql" />
+    <EmbeddedResource Include="Scripts\OracleBuildDatabaseOrdinary.sql" />
+    <EmbeddedResource Include="Scripts\OracleSetupDatabaseDelimited.sql" />
+    <EmbeddedResource Include="Scripts\OracleSetupDatabaseOrdinary.sql" />
     <EmbeddedResource Include="Scripts\PostgresBuildDatabase.sql" />
     <EmbeddedResource Include="Scripts\SQLiteBuildDatabase.sql" />
     <EmbeddedResource Include="Scripts\SqlServerBuildDatabase.sql" />

--- a/PetaPoco.Tests.Integration/Scripts/OracleBuildDatabaseDelimited.sql
+++ b/PetaPoco.Tests.Integration/Scripts/OracleBuildDatabaseDelimited.sql
@@ -1,0 +1,190 @@
+﻿-- Case Sensitive version of OracleBuildDatabaseOrdinary.sql
+CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco_delimited."OrderLines"');
+/
+CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco_delimited."Orders"');
+/
+CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco_delimited."People"');
+/
+CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco_delimited."SpecificOrderLines"');
+/
+CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco_delimited."SpecificOrders"');
+/
+CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco_delimited."SpecificPeople"');
+/
+CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco_delimited."TransactionLogs"');
+/
+CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco_delimited."Note"');
+/
+
+CREATE TABLE "People" (
+	"Id" VARCHAR2(36) NOT NULL,
+	"FullName" VARCHAR2(255),
+	"Age" NUMBER(19) NOT NULL,
+	"Height" NUMBER(10) NOT NULL,
+	"Dob" TIMESTAMP NULL,
+    PRIMARY KEY("Id")
+);
+
+CREATE TABLE "Orders" (
+	"Id" NUMBER(10) GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1),
+	"PersonId" VARCHAR2(36),
+	"PoNumber" VARCHAR2(15) NOT NULL,
+	"OrderStatus" NUMBER(10) NOT NULL,
+	"CreatedOn" TIMESTAMP NOT NULL,
+	"CreatedBy" VARCHAR2(255) NOT NULL,
+    PRIMARY KEY("Id"),
+    FOREIGN KEY ("PersonId") REFERENCES "People"("Id")
+);
+
+CREATE TABLE "OrderLines" (
+	"Id" NUMBER(10) GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1),
+	"OrderId" NUMBER(10) NOT NULL,
+	"Qty" NUMBER(5) NOT NULL,
+	"Status" NUMBER(3) NOT NULL,
+	"SellPrice" NUMERIC(10, 4) NOT NULL,
+    PRIMARY KEY("Id"),
+    FOREIGN KEY ("OrderId") REFERENCES "Orders"("Id")
+);
+
+CREATE TABLE "SpecificPeople" (
+	"Id" VARCHAR2(36) NOT NULL,
+	"FullName" VARCHAR2(255),
+	"Age" NUMBER(19) NOT NULL,
+	"Height" NUMBER(10) NOT NULL,
+	"Dob" TIMESTAMP NULL,
+    PRIMARY KEY("Id")
+);
+
+CREATE TABLE "SpecificOrders" (
+	"Id" NUMBER(10) GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1),
+	"PersonId" VARCHAR2(36),
+	"PoNumber" VARCHAR2(15) NOT NULL,
+	"OrderStatus" NUMBER(10) NOT NULL,
+	"CreatedOn" TIMESTAMP NOT NULL,
+	"CreatedBy" VARCHAR2(255) NOT NULL,
+    PRIMARY KEY("Id"),
+    FOREIGN KEY("PersonId") REFERENCES "SpecificPeople"("Id")
+);
+
+CREATE TABLE "SpecificOrderLines" (
+	"Id" NUMBER(10) GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1),
+	"OrderId" NUMBER(10) NOT NULL,
+	"Qty" NUMBER(5) NOT NULL,
+	"Status" NUMBER(3) NOT NULL,
+	"SellPrice" NUMBER(10, 4) NOT NULL,
+    PRIMARY KEY("Id"),
+    FOREIGN KEY("OrderId") REFERENCES "SpecificOrders"("Id")
+);
+
+CREATE TABLE "TransactionLogs" (
+	"Description" LONG,
+	"CreatedOn" TIMESTAMP NOT NULL
+);
+
+CREATE TABLE "Note" (
+	"Id" NUMBER(10) GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1),
+	"Text" LONG NOT NULL,
+	"CreatedOn" TIMESTAMP NOT NULL
+);
+/
+
+-- Investigation Tables
+CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco_delimited."BugInvestigation_10R9LZYK"');
+/
+CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco_delimited."BugInvestigation_3F489XV0"');
+/
+CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco_delimited."BugInvestigation_64O6LT8U"');
+/
+CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco_delimited."BugInvestigation_5TN5C4U4"');
+/
+
+CREATE TABLE "BugInvestigation_10R9LZYK" (
+	"Id" NUMBER(10) GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1),
+	"TestColumn1" LONG RAW,
+    PRIMARY KEY("Id")
+);
+/
+
+CREATE TABLE "BugInvestigation_3F489XV0" (
+	"Id" NUMBER(10) GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1),
+	"TC1" NUMBER(10) NOT NULL,
+	"TC2" NUMBER(10) NOT NULL,
+	"TC3" NUMBER(10) NOT NULL,
+	"TC4" NUMBER(10) NOT NULL,
+    PRIMARY KEY("Id")
+);
+/
+
+CREATE TABLE "BugInvestigation_64O6LT8U" (
+	"ColumnA" VARCHAR2(20),
+	"Column2" VARCHAR2(20)
+);
+/
+
+CREATE TABLE "BugInvestigation_5TN5C4U4" (
+	"ColumnA" VARCHAR2(20),
+	"Column2" VARCHAR2(20)
+);
+/
+
+-- Stored procedures
+CALL SYS.DROP_IF_EXISTS('PROCEDURE', 'petapoco_delimited."SelectPeople"');
+/
+CALL SYS.DROP_IF_EXISTS('PROCEDURE', 'petapoco_delimited."SelectPeopleWithParam"');
+/
+CALL SYS.DROP_IF_EXISTS('PROCEDURE', 'petapoco_delimited."CountPeople"');
+/
+CALL SYS.DROP_IF_EXISTS('PROCEDURE', 'petapoco_delimited."CountPeopleWithParam"');
+/
+CALL SYS.DROP_IF_EXISTS('PROCEDURE', 'petapoco_delimited."UpdatePeople"');
+/
+CALL SYS.DROP_IF_EXISTS('PROCEDURE', 'petapoco_delimited."UpdatePeopleWithParam"');
+/
+
+CREATE PROCEDURE "SelectPeople"
+    ("p_out_cursor" OUT SYS_REFCURSOR) AS
+BEGIN
+	OPEN "p_out_cursor" FOR
+	SELECT * FROM "People";
+END;
+/
+
+CREATE PROCEDURE "SelectPeopleWithParam"
+    ("age" IN NUMERIC DEFAULT 0,
+    "p_out_cursor" OUT SYS_REFCURSOR) AS
+BEGIN
+	OPEN "p_out_cursor" FOR
+	SELECT * FROM "People" WHERE "Age" > "SelectPeopleWithParam"."age";
+END;
+/
+
+CREATE PROCEDURE "CountPeople"
+    ("p_out_cursor" OUT SYS_REFCURSOR)
+AS
+BEGIN
+	OPEN "p_out_cursor" FOR
+	SELECT COUNT(*) FROM "People";
+END;
+/
+
+CREATE PROCEDURE "CountPeopleWithParam"
+	("age" IN NUMERIC DEFAULT 0,
+    "p_out_cursor" OUT SYS_REFCURSOR) AS
+BEGIN
+	OPEN "p_out_cursor" FOR
+	SELECT COUNT(*) FROM "People" WHERE "Age" > "CountPeopleWithParam"."age";
+END;
+/
+
+CREATE PROCEDURE "UpdatePeople" AS
+BEGIN
+	UPDATE "People" SET "FullName" = 'Updated';
+END;
+/
+
+CREATE PROCEDURE "UpdatePeopleWithParam"
+	("age" IN NUMERIC DEFAULT 0) AS
+BEGIN
+	UPDATE "People" SET "FullName" = 'Updated' WHERE "Age" > "UpdatePeopleWithParam"."age";
+END;
+/

--- a/PetaPoco.Tests.Integration/Scripts/OracleBuildDatabaseOrdinary.sql
+++ b/PetaPoco.Tests.Integration/Scripts/OracleBuildDatabaseOrdinary.sql
@@ -1,18 +1,19 @@
-﻿CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco.OrderLines');
+﻿-- Case Insensitive version of OracleBuildDatabaseDelimited.sql
+CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco_ordinary.OrderLines');
 /
-CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco.Orders');
+CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco_ordinary.Orders');
 /
-CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco.People');
+CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco_ordinary.People');
 /
-CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco.SpecificOrderLines');
+CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco_ordinary.SpecificOrderLines');
 /
-CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco.SpecificOrders');
+CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco_ordinary.SpecificOrders');
 /
-CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco.SpecificPeople');
+CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco_ordinary.SpecificPeople');
 /
-CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco.TransactionLogs');
+CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco_ordinary.TransactionLogs');
 /
-CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco.Note');
+CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco_ordinary.Note');
 /
 
 CREATE TABLE People (
@@ -88,13 +89,13 @@ CREATE TABLE Note (
 /
 
 -- Investigation Tables
-CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco.BugInvestigation_10R9LZYK');
+CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco_ordinary.BugInvestigation_10R9LZYK');
 /
-CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco.BugInvestigation_3F489XV0');
+CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco_ordinary.BugInvestigation_3F489XV0');
 /
-CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco.BugInvestigation_64O6LT8U');
+CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco_ordinary.BugInvestigation_64O6LT8U');
 /
-CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco.BugInvestigation_5TN5C4U4');
+CALL SYS.DROP_IF_EXISTS('TABLE', 'petapoco_ordinary.BugInvestigation_5TN5C4U4');
 /
 
 CREATE TABLE BugInvestigation_10R9LZYK (
@@ -127,17 +128,17 @@ CREATE TABLE BugInvestigation_5TN5C4U4 (
 /
 
 -- Stored procedures
-CALL SYS.DROP_IF_EXISTS('PROCEDURE', 'petapoco.SelectPeople');
+CALL SYS.DROP_IF_EXISTS('PROCEDURE', 'petapoco_ordinary.SelectPeople');
 /
-CALL SYS.DROP_IF_EXISTS('PROCEDURE', 'petapoco.SelectPeopleWithParam');
+CALL SYS.DROP_IF_EXISTS('PROCEDURE', 'petapoco_ordinary.SelectPeopleWithParam');
 /
-CALL SYS.DROP_IF_EXISTS('PROCEDURE', 'petapoco.CountPeople');
+CALL SYS.DROP_IF_EXISTS('PROCEDURE', 'petapoco_ordinary.CountPeople');
 /
-CALL SYS.DROP_IF_EXISTS('PROCEDURE', 'petapoco.CountPeopleWithParam');
+CALL SYS.DROP_IF_EXISTS('PROCEDURE', 'petapoco_ordinary.CountPeopleWithParam');
 /
-CALL SYS.DROP_IF_EXISTS('PROCEDURE', 'petapoco.UpdatePeople');
+CALL SYS.DROP_IF_EXISTS('PROCEDURE', 'petapoco_ordinary.UpdatePeople');
 /
-CALL SYS.DROP_IF_EXISTS('PROCEDURE', 'petapoco.UpdatePeopleWithParam');
+CALL SYS.DROP_IF_EXISTS('PROCEDURE', 'petapoco_ordinary.UpdatePeopleWithParam');
 /
 
 CREATE PROCEDURE SelectPeople

--- a/PetaPoco.Tests.Integration/Scripts/OracleSetupDatabaseDelimited.sql
+++ b/PetaPoco.Tests.Integration/Scripts/OracleSetupDatabaseDelimited.sql
@@ -1,0 +1,27 @@
+-- Drop PETAPOCO_ORDINARY user COMPLETELY (if it exists)
+DECLARE
+    found number := 0;
+BEGIN
+    SELECT COUNT(*) INTO found
+    FROM all_users
+    WHERE username = 'PETAPOCO_DELIMITED';
+
+    IF found <> 0 THEN
+        BEGIN
+            EXECUTE IMMEDIATE 'DROP USER petapoco_delimited CASCADE';
+        END;
+    END IF;
+END;
+/
+
+-- Create fresh user
+CREATE USER petapoco_delimited IDENTIFIED BY petapoco;
+
+-- Ensure that the data tablespace is the default for the user. This tablespace will be used when creating tables for example
+ALTER USER petapoco_delimited DEFAULT TABLESPACE data_ts;
+-- Give user quota e.g. to perform inserts
+ALTER USER petapoco_delimited QUOTA UNLIMITED ON data_ts;
+
+-- Grant the application developer role
+GRANT app_dev_role TO petapoco_delimited;
+/

--- a/PetaPoco.Tests.Integration/Scripts/OracleSetupDatabaseOrdinary.sql
+++ b/PetaPoco.Tests.Integration/Scripts/OracleSetupDatabaseOrdinary.sql
@@ -1,0 +1,27 @@
+-- Drop PETAPOCO_ORDINARY user COMPLETELY (if it exists)
+DECLARE
+    found number := 0;
+BEGIN
+    SELECT COUNT(*) INTO found
+    FROM all_users
+    WHERE username = 'PETAPOCO_ORDINARY';
+
+    IF found <> 0 THEN
+        BEGIN
+            EXECUTE IMMEDIATE 'DROP USER petapoco_ordinary CASCADE';
+        END;
+    END IF;
+END;
+/
+
+-- Create fresh user
+CREATE USER petapoco_ordinary IDENTIFIED BY petapoco;
+
+-- Ensure that the data tablespace is the default for the user. This tablespace will be used when creating tables for example
+ALTER USER petapoco_ordinary DEFAULT TABLESPACE data_ts;
+-- Give user quota e.g. to perform inserts
+ALTER USER petapoco_ordinary QUOTA UNLIMITED ON data_ts;
+
+-- Grant the application developer role
+GRANT app_dev_role TO petapoco_ordinary;
+/

--- a/PetaPoco.Tests.Integration/app.config
+++ b/PetaPoco.Tests.Integration/app.config
@@ -13,7 +13,8 @@
     <add name="SqlServerMSData_Builder" connectionString="Data Source=localhost,5007;User ID=sa;Password=pAtAp0c8" providerName="Microsoft.Data.SqlClient" />
     <add name="SqlServerMSData" connectionString="Data Source=localhost,5007;Initial Catalog=PetaPocoMSData;User ID=sa;Password=pAtAp0c8" providerName="Microsoft.Data.SqlClient" />
     <add name="Oracle_Builder" connectionString="Data Source=(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=5008))(CONNECT_DATA=(SERVICE_NAME=FREEPDB1)));User Id=sys;Password=petapoco;DBA PRIVILEGE=sysdba" providerName="Oracle.ManagedDataAccess"/>
-    <add name="Oracle" connectionString="Data Source=(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=5008))(CONNECT_DATA=(SERVICE_NAME=FREEPDB1)));User Id=petapoco;Password=petapoco;" providerName="Oracle.ManagedDataAccess"/>
+    <add name="Oracle_Delimited" connectionString="Data Source=(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=5008))(CONNECT_DATA=(SERVICE_NAME=FREEPDB1)));User Id=petapoco_delimited;Password=petapoco;" providerName="Oracle.ManagedDataAccess"/>
+    <add name="Oracle_Ordinary" connectionString="Data Source=(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=5008))(CONNECT_DATA=(SERVICE_NAME=FREEPDB1)));User Id=petapoco_ordinary;Password=petapoco;" providerName="Oracle.ManagedDataAccess"/>
     <!-- Env: Local development environment -->
     <add name="SQLite" connectionString="Data Source=PetaPoco.sqlite;Version=3;Pooling=True;Max Pool Size=100" providerName="System.Data.SQLite" />
     <add name="SQLiteMSData" connectionString="Data Source=PetaPocoMSData.sqlite;Version=3;Pooling=True;Max Pool Size=100" providerName="Microsoft.Data.SQLite" />

--- a/PetaPoco.Tests.Integration/appsettings.json
+++ b/PetaPoco.Tests.Integration/appsettings.json
@@ -52,8 +52,13 @@
         "ProviderName": "Oracle.ManagedDataAccess"
       },
       {
-        "Name": "Oracle",
-        "ConnectionString": "Data Source=(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=5008))(CONNECT_DATA=(SERVICE_NAME=FREEPDB1)));User Id=petapoco;Password=petapoco;",
+        "Name": "Oracle_Delimited",
+        "ConnectionString": "Data Source=(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=5008))(CONNECT_DATA=(SERVICE_NAME=FREEPDB1)));User Id=petapoco_delimited;Password=petapoco;",
+        "ProviderName": "Oracle.ManagedDataAccess"
+      },
+      {
+        "Name": "Oracle_Ordinary",
+        "ConnectionString": "Data Source=(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=5008))(CONNECT_DATA=(SERVICE_NAME=FREEPDB1)));User Id=petapoco_ordinary;Password=petapoco;",
         "ProviderName": "Oracle.ManagedDataAccess"
       },
       {

--- a/PetaPoco/Database.cs
+++ b/PetaPoco/Database.cs
@@ -3162,9 +3162,13 @@ namespace PetaPoco
                     idbParam.ParameterName = cmd.Parameters.Count.EnsureParamPrefix(_paramPrefix);
                 else if (idbParam.ParameterName?.StartsWith(_paramPrefix) != true)
                 {
-                    // only add param prefix if it's not an Oracle stored procedures
-                    if (!(cmd.CommandType == CommandType.StoredProcedure && _provider is Providers.OracleDatabaseProvider))
-                        idbParam.ParameterName = idbParam.ParameterName.EnsureParamPrefix(_paramPrefix);
+                    var isOracleStoredProc = cmd.CommandType == CommandType.StoredProcedure &&
+                        _provider is Providers.OracleDatabaseProvider;
+
+                    // if it's an Oracle stored procedure, only escape the parameter name, don't add param prefix
+                    idbParam.ParameterName = isOracleStoredProc ?
+                        _provider.EscapeSqlIdentifier(idbParam.ParameterName) :
+                        idbParam.ParameterName.EnsureParamPrefix(_paramPrefix);
                 }
 
                 cmd.Parameters.Add(idbParam);

--- a/PetaPoco/Utilities/ParametersHelper.cs
+++ b/PetaPoco/Utilities/ParametersHelper.cs
@@ -18,8 +18,8 @@ namespace PetaPoco.Internal
     /// </remarks>
     internal static class ParametersHelper
     {
-        private static Regex ParamPrefixRegex = new Regex(@"(?<!@)@\w+", RegexOptions.Compiled);
-        private static Regex NonWordStartRegex = new Regex(@"^\W*", RegexOptions.Compiled);
+        private static readonly Regex ParamPrefixRegex = new Regex(@"(?<!@)@\w+", RegexOptions.Compiled);
+        private static readonly Regex NonWordStartRegex = new Regex(@"^\W*", RegexOptions.Compiled);
 
         /// <summary>
         /// Replaces all parameter prefixes in the provided SQL statement with the specified replacement string.
@@ -71,8 +71,7 @@ namespace PetaPoco.Internal
 
                 object arg_val;
 
-                int paramIndex;
-                if (int.TryParse(param, out paramIndex))
+                if (int.TryParse(param, out int paramIndex))
                 {
                     // Numbered parameter
                     if (paramIndex < 0 || paramIndex >= srcArgs.Length)
@@ -115,7 +114,7 @@ namespace PetaPoco.Internal
                 if (arg_val.IsEnumerable())
                 {
                     var sb = new StringBuilder();
-                    foreach (var i in (arg_val as System.Collections.IEnumerable))
+                    foreach (var i in (arg_val as IEnumerable))
                     {
                         sb.Append((sb.Length == 0 ? "@" : ",@") + destArgs.Count.ToString());
                         destArgs.Add(i);
@@ -160,13 +159,13 @@ namespace PetaPoco.Internal
                 }
                 else if (arg.IsEnumerable())
                 {
-                    foreach (var singleArg in (arg as System.Collections.IEnumerable))
+                    foreach (var singleArg in (arg as IEnumerable))
                     {
                         ProcessArg(singleArg);
                     }
                 }
-                else if (arg is IDbDataParameter)
-                    result.Add((IDbDataParameter)arg);
+                else if (arg is IDbDataParameter dataParam)
+                    result.Add(dataParam);
                 else
                 {
                     var type = arg.GetType();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,5 +84,7 @@ services:
       - "5008:1521"
     environment:
       <<: *oracle-environment
+    volumes:
+      - ./Scripts/Startup:/opt/oracle/scripts/startup
 
   # TODO: teradata


### PR DESCRIPTION
Test Oracle Delimited and Ordinary Identifiers Separately.

#### IntegrationTests
Split Oracle DB scripts, connection strings and tests in two.
One set of tests to use PP OOTB (Delimited) and one set of tests to use PP with Custom provider and mapper (Ordinary).
Fix Oracle setup script. Wait for tablespace drop operation to complete before creating the new tablespace.

#### Core
**Database.cs**
- Escape Oracle Stored Procedure parameter names instead of ensuring paramater prefix.

**OracleDatabaseProvider.cs**
- Quote identifier when escaping (no Regex or ToUpperInvariant).
- Disable statement caching for Oracle client.