### PR TITLE
Fix PocoData Cache Issue

### DIFF
--- a/PetaPoco/Database.cs
+++ b/PetaPoco/Database.cs
@@ -3054,7 +3054,7 @@ namespace PetaPoco
             {
                 param.Value = DBNull.Value;
 
-                if (pocoColumn?.PropertyInfo.PropertyType.Name == "Byte[]")
+                if (pocoColumn?.PropertyInfo?.PropertyType.Name == "Byte[]")
                     param.DbType = DbType.Binary;
             }
             else


### PR DESCRIPTION
Include Mapper Type in cache key for PocoData. Fixes #517.

Avoid "duplicate key" side effect in `PocoData.ForObject` method when handling dynamic objects.