### PR TITLE
Update Npgsql to v4.1.13

### DIFF
--- a/PetaPoco.Tests.Integration/PetaPoco.Tests.Integration.csproj
+++ b/PetaPoco.Tests.Integration/PetaPoco.Tests.Integration.csproj
@@ -86,7 +86,7 @@
     <PackageReference Include="Microsoft.SqlServer.Compact" Version="4.0.8876.1" Condition="'$(TargetFramework)' != 'netcoreapp2.1'" />
     <PackageReference Include="MySql.Data" Version="8.0.21" />
     <PackageReference Include="MySqlConnector" Version="1.0.1" />
-    <PackageReference Include="Npgsql" Version="4.1.4" />
+    <PackageReference Include="Npgsql" Version="4.1.13" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.113.1" />
   </ItemGroup>


### PR DESCRIPTION
Npgsql has a high-severity vulnerability, which they take seriously enough to issue new builds of out-of-support versions. It doesn't matter that much for this project, since the dependency is only in the integration tests project, but merging this will make Dependabot happy.

As a side note, it would probably be a good idea to go through the test projects and update frameworks and libraries to more recent versions. I can take a look at this if I can get the Docker stuff running on my new machine.