### PR TITLE
Fix MS Access Delete test failure due to Int64 parameter conversion

### DIFF
--- a/PetaPoco/Providers/MSAccessDatabaseProvider.cs
+++ b/PetaPoco/Providers/MSAccessDatabaseProvider.cs
@@ -32,6 +32,26 @@ namespace PetaPoco.Providers
             return ExecuteScalarHelper(db, cmd);
         }
 
+        /// <inheritdoc/>
+        public override object MapParameterValue(object value)
+        {
+            // MS Access 'Long' type is a 32-bit integer. Convert Int64 to Int32 where safe to avoid OLE DB conversion errors.
+            if (value is long l)
+            {
+                if (l <= int.MaxValue && l >= int.MinValue)
+                    return (int)l;
+            }
+
+            if (value is ulong ul)
+            {
+                if (ul <= (ulong)int.MaxValue)
+                    return (int)ul;
+            }
+
+            // Let base handle other common conversions (eg: bool -> int)
+            return base.MapParameterValue(value);
+        }
+
 #if ASYNC
         /// <inheritdoc/>
         public override async Task<object> ExecuteInsertAsync(CancellationToken cancellationToken, Database db, IDbCommand cmd, string primaryKeyName)


### PR DESCRIPTION
#734 

Resolves many Access DB related failing tests:
- MSAccessDeleteTests.Delete_GivenPoco_ShouldDeletePoco
- Insert_GivenPoco_ShouldBeValid
- InsertAsync_GivenPoco_ShouldBeValid
- Too many to list here

Problem:
The test failed with "Command parameter[2] '' data value could not be converted for reasons other than sign mismatch or data overflow" when inserting Person records with Int64 Age values into MS Access.

Root cause:
MS Access 'Long' column type is 32-bit (Int32), but the Person.Age property is defined as C# long (Int64). The OLE DB provider cannot implicitly convert 64-bit parameters to 32-bit columns, causing multiple-step OLE DB operation errors during insert/delete operations.

Solution:
Override MapParameterValue in MsAccessDbDatabaseProvider to explicitly convert Int64/UInt64 parameter values to Int32 when the value fits within Int32 range. This ensures compatibility with MS Access Long columns while preserving data integrity.

Changes:
- Added Int64 -> Int32 conversion with range check (Int32.Min/Max)
- Added UInt64 -> Int32 conversion with range check
- Falls back to base MapParameterValue for other conversions (bool->int)

Impact:
Fixes all MS Access CRUD operations involving long/Int64 properties mapped to Long columns (People.Age, etc.)